### PR TITLE
Fix cmake for cross-compiling

### DIFF
--- a/ggml/src/ggml-rknpu2/CMakeLists.txt
+++ b/ggml/src/ggml-rknpu2/CMakeLists.txt
@@ -22,8 +22,13 @@ target_link_libraries(ggml-rknpu2 PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/librknnrt.so
 )
 
+target_link_options(ggml-rknpu2 PUBLIC
+    "-Wl,-rpath-link,${CMAKE_CURRENT_SOURCE_DIR}/libs"
+)
+
 # Adding OpenMP in build
 if(OpenMP_FOUND)
     add_definitions(-DHAVE_OPENMP=1)
-    list(APPEND CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS}")
+    target_compile_options(ggml-rknpu2 PRIVATE ${OpenMP_CXX_FLAGS})
+    target_link_libraries(ggml-rknpu2 PRIVATE ${OpenMP_CXX_FLAGS})
 endif()


### PR DESCRIPTION
1. When CMAKE_CXX_FLAGS is not empty, list(APPEND CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS}")  causes a semi-colon to be inserted between CMAKE_CXX_FLAGS and ${OpenMP_CXX_FLAGS} which breaks the build command line
2. Linker cannot find libs/librknnrt.so unless -Wl,-rpath-link points to the folder