### PR TITLE
ggml-rknpu2: opt-in batched mul_mat path (F8.5)

### DIFF
--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -69,6 +69,10 @@ struct RknpuRouteStats {
     std::atomic<uint64_t> accepted_batched{0};
     std::atomic<uint64_t> dispatched_static{0};
     std::atomic<uint64_t> dispatched_dynamic{0};
+    std::atomic<uint64_t> set_tensor_calls{0};
+    std::atomic<uint64_t> set_tensor_first_pipelined{0};   // first set_tensor on a pipelined alloc
+    std::atomic<uint64_t> set_tensor_repeat_pipelined{0};  // subsequent calls (demote path)
+    std::atomic<uint64_t> set_tensor_no_pipeline{0};       // memcpy fallback
 };
 
 static RknpuRouteStats& rknpu_route_stats() {
@@ -82,7 +86,8 @@ static void rknpu_print_route_stats(const char* label) {
         "RKNPU_ROUTE_STATS %s: mul_mat_total=%lu "
         "rejected_rank=%lu rejected_batched_off=%lu rejected_min_m=%lu rejected_cbuf=%lu rejected_other=%lu "
         "accepted_rank2=%lu accepted_batched=%lu "
-        "dispatched_static=%lu dispatched_dynamic=%lu\n",
+        "dispatched_static=%lu dispatched_dynamic=%lu "
+        "set_tensor_calls=%lu set_tensor_first_pipelined=%lu set_tensor_repeat_pipelined=%lu set_tensor_no_pipeline=%lu\n",
         label,
         (unsigned long)s.mul_mat_total.load(),
         (unsigned long)s.rejected_rank.load(),
@@ -93,7 +98,11 @@ static void rknpu_print_route_stats(const char* label) {
         (unsigned long)s.accepted_rank2.load(),
         (unsigned long)s.accepted_batched.load(),
         (unsigned long)s.dispatched_static.load(),
-        (unsigned long)s.dispatched_dynamic.load());
+        (unsigned long)s.dispatched_dynamic.load(),
+        (unsigned long)s.set_tensor_calls.load(),
+        (unsigned long)s.set_tensor_first_pipelined.load(),
+        (unsigned long)s.set_tensor_repeat_pipelined.load(),
+        (unsigned long)s.set_tensor_no_pipeline.load());
 }
 
 // TST.3 / debug override: when RKNPU_FORCE_DYNAMIC_B=1, graph_compute
@@ -662,6 +671,34 @@ static void ggml_backend_rknpu_free(ggml_backend_t backend) {
     delete backend;
 }
 
+// F8.5.STAT — debug helper to inspect per-buffer set_count distribution at
+// buffer free time. Shows how many tensors went through set_tensor>=2
+// times (the demote path), and the max observed count. Helps locate why
+// dispatched_dynamic stays 0 in production despite accepted_batched > 0.
+static void rknpu_log_buffer_set_count_histogram(const ggml_backend_rknpu_buffer_context* ctx, const char* label) {
+    if (!ctx) return;
+    int total_allocs = 0;
+    int set_count_zero = 0;
+    int set_count_one = 0;
+    int set_count_ge_two = 0;
+    int max_set_count = 0;
+    int pre_quantized = 0;
+    for (const auto& pair : ctx->tensor_allocs) {
+        ++total_allocs;
+        const int sc = pair.second.set_count;
+        if (sc == 0) ++set_count_zero;
+        else if (sc == 1) ++set_count_one;
+        else ++set_count_ge_two;
+        if (sc > max_set_count) max_set_count = sc;
+        if (pair.second.pre_quantized) ++pre_quantized;
+    }
+    std::fprintf(stderr,
+        "RKNPU_BUFFER_FREE %s: name=%s allocs=%d set_count{0=%d, 1=%d, >=2=%d} max=%d pre_quantized_now=%d\n",
+        label,
+        ctx->name.c_str(),
+        total_allocs, set_count_zero, set_count_one, set_count_ge_two, max_set_count, pre_quantized);
+}
+
 // Function for acquiring a pointer for tensor data
 static void* get_tensor_real_ptr(const struct ggml_tensor* tensor) {
     if (!tensor || !tensor->data) return nullptr;
@@ -970,15 +1007,18 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                 static std::mutex m;
                 static std::unordered_set<std::string> seen;
                 char key[512];
+                const char* buf_name = (src0->buffer && src0->buffer->buft && src0->buffer->buft->iface.get_name)
+                    ? src0->buffer->buft->iface.get_name(src0->buffer->buft) : "?";
                 std::snprintf(key, sizeof(key),
-                    "ROUTED static=%d M=%d K=%d N=%d n_heads=%d M_total=%d src0=%s/%s/op=%d/view_src=%p/flags=0x%x src1=%s dst=%s op=%s",
-                    use_static_path ? 1 : 0, M, K, N, n_heads, M_total,
+                    "ROUTED static=%d in_rknpu=%d pre_q=%d M=%d K=%d N=%d n_heads=%d M_total=%d src0=%s/%s/buft=%s/op=%d/view_src=%p/flags=0x%x dst=%s op=%s",
+                    use_static_path ? 1 : 0, is_rknpu_buffer(src0) ? 1 : 0, src0_is_pre_quantized ? 1 : 0,
+                    M, K, N, n_heads, M_total,
                     ggml_type_name(src0->type),
                     src0->name[0] ? src0->name : "?",
+                    buf_name,
                     (int)src0->op,
                     (void*)src0->view_src,
                     (unsigned)src0->flags,
-                    ggml_type_name(src1->type),
                     ggml_type_name(dst->type),
                     node->name[0] ? node->name : "?");
                 std::lock_guard<std::mutex> lock(m);
@@ -1215,6 +1255,10 @@ static size_t get_tensor_packed_size(const struct ggml_tensor * tensor) {
 
 static void ggml_backend_rknpu_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     ggml_backend_rknpu_buffer_context * ctx = (ggml_backend_rknpu_buffer_context *)buffer->context;
+
+    if (rknpu_batched_diag_enabled()) {
+        rknpu_log_buffer_set_count_histogram(ctx, "free_buffer");
+    }
 
     // Freeing an every individual RKNN buffer using the allocator context
     for (auto& pair : ctx->tensor_allocs) {
@@ -1526,6 +1570,8 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
 
     size_t tensor_offset_in_virtual = (uintptr_t)tensor->data - (uintptr_t)ctx->virtual_base;
 
+    rknpu_route_stats().set_tensor_calls.fetch_add(1, std::memory_order_relaxed);
+
     // F8.3: pre-quantize only the FIRST set_tensor call against an alloc.
     // Real weights see exactly one such call at model load. Scheduler-managed
     // copy tensors (the F16 KV-cache slices ggml_backend_sched dups into the
@@ -1544,10 +1590,14 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
         const int prev_count = it->second.set_count++;
         if (prev_count == 0) {
             is_first_call = true;
+            rknpu_route_stats().set_tensor_first_pipelined.fetch_add(1, std::memory_order_relaxed);
         } else {
             is_repeat_call = true;
             it->second.pre_quantized = false;
+            rknpu_route_stats().set_tensor_repeat_pipelined.fetch_add(1, std::memory_order_relaxed);
         }
+    } else {
+        rknpu_route_stats().set_tensor_no_pipeline.fetch_add(1, std::memory_order_relaxed);
     }
 
     if (pipeline && is_first_call) {

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -859,11 +859,11 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
 
             std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
             auto it = src0_buf_ctx->tensor_allocs.find(tensor_offset_in_virtual);
-            if (it != src0_buf_ctx->tensor_allocs.end() && it->second.pre_quantized) {
-                src0_is_pre_quantized = true;
+            if (it != src0_buf_ctx->tensor_allocs.end()) {
+                b_domain_id = it->second.iommu_domain_id;
+                src0_is_pre_quantized = it->second.pre_quantized;
                 tensor_fd = it->second.mem->fd;
                 tensor_virt_addr = it->second.mem->virt_addr;
-                b_domain_id = it->second.iommu_domain_id;
             }
         }
         const bool use_static_path = src0_is_pre_quantized && !rknpu_force_dynamic_b();
@@ -978,7 +978,7 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                         // pre-quantized weight. Reuse a shape-keyed matmul ctx
                         // and a shape-keyed DMA buffer, but re-fill the B
                         // contents and re-bind every call.
-                        const int32_t domain_id = 0;
+                        const int32_t domain_id = b_domain_id;
 
                         matmul_ctxs[idx] = backend_ctx->get_dynamic_matmul_ctx(
                             M_op, K_seg_op, n_seg.size_n,
@@ -1590,15 +1590,17 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
 
     rknpu_route_stats().set_tensor_calls.fetch_add(1, std::memory_order_relaxed);
 
-    // F8.3: pre-quantize only the FIRST set_tensor call against an alloc.
+    // F8.3: pre-quantize only the first full set_tensor call against an alloc.
     // Real weights see exactly one such call at model load. Scheduler-managed
     // copy tensors (the F16 KV-cache slices ggml_backend_sched dups into the
     // RKNPU buffer for batched attention) see a fresh set_tensor every step —
     // demote those to memcpy so graph_compute reads fresh values via the
-    // dynamic path. INPUT/OUTPUT flags are unreliable (the sched only sets
-    // them when n_copies > 1; default n_copies is 1), so we count the calls.
+    // dynamic path. Partial writes are also memcpy-only: pre-quantizing the
+    // whole tensor from a partial source buffer would read beyond the source.
+    // INPUT/OUTPUT flags are unreliable (the sched only sets them when
+    // n_copies > 1; default n_copies is 1), so we count the calls.
     bool is_first_call = false;
-    bool is_repeat_call = false;
+    const bool is_full_tensor_set = (offset == 0 && size == ggml_nbytes(tensor));
     if (pipeline) {
         size_t required_size = get_tensor_packed_size(tensor);
         ctx->get_tensor_allocation(tensor_offset_in_virtual, required_size);
@@ -1606,11 +1608,10 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
         auto it = ctx->tensor_allocs.find(tensor_offset_in_virtual);
         GGML_ASSERT(it != ctx->tensor_allocs.end());
         const int prev_count = it->second.set_count++;
-        if (prev_count == 0) {
+        if (prev_count == 0 && is_full_tensor_set) {
             is_first_call = true;
             rknpu_route_stats().set_tensor_first_pipelined.fetch_add(1, std::memory_order_relaxed);
         } else {
-            is_repeat_call = true;
             it->second.pre_quantized = false;
             rknpu_route_stats().set_tensor_repeat_pipelined.fetch_add(1, std::memory_order_relaxed);
         }

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -667,6 +667,24 @@ static void ggml_backend_rknpu_free(ggml_backend_t backend) {
     // benches/PPL runs can verify what actually ran on the NPU vs CPU.
     rknpu_print_route_stats("backend_free");
     ggml_backend_rknpu_context * ctx = (ggml_backend_rknpu_context *)backend->context;
+
+    // Cleanup ordering fix: a/c/b buffer caches all hold shared_ptr<rknn_tensor_mem>
+    // whose deleters captured the rknn_matmul_ctx handle that allocated each mem.
+    // The handles must still be valid when the deleters fire. With both static
+    // and dynamic paths populating c_buffer_cache and a_buffer_cache, those
+    // caches contain mems whose captured handle came from EITHER matmul_ctx_cache
+    // OR dynamic_matmul_ctx_cache. Destroying ctx caches first leaves stale
+    // handles in the buffer caches, which segfaults inside rknn_destroy_mem.
+    // Solution: clear ALL buffer caches before ANY ctx cache.
+    {
+        std::lock_guard<std::mutex> lock(ctx->mutex);
+        ctx->b_dynamic_buffer_cache.clear();
+        ctx->c_buffer_cache.clear();
+        ctx->a_buffer_cache.clear();
+        ctx->dynamic_matmul_ctx_cache.clear();
+        ctx->matmul_ctx_cache.clear();
+    }
+
     delete ctx;
     delete backend;
 }

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -67,6 +67,44 @@ static bool rknpu_force_dynamic_b() {
     return enabled;
 }
 
+// F8.6b stability cap: max M_total (= M * n_heads) safe for one matmul
+// submission, derived from RK3588 NPU CBUF limits. CBUF has 12 banks ×
+// 32 KB; the librknnrt 2.3.2 driver appears to need at least 2 banks
+// reserved for weight, leaving (12-2)*32768 bytes for data. A row of
+// A occupies align_up(K, 32) * sizeof(npu_type_a) bytes, so
+//   max_M = 10 * 32768 / (align_up(K, 32) * type_a_bytes).
+// Crossing this segfaults inside librknnrt for the affected shape
+// (observed at M_total=2048, K=512, FP16). Reference: allbilly/npu
+// matmul_fix_424 branch, which solves the same limit with explicit
+// M-tiling. We currently only gate; F8.6c can replace the gate with
+// a real M-tile loop.
+static int rknpu_max_m_for_cbuf(const rknpu2_configuration::Rknpu2HardwarePipeline* pipeline, int K_seg) {
+    constexpr int CBUF_BANK_BYTES = 32768;
+    constexpr int CBUF_BANKS = 12;
+    constexpr int WEIGHT_BANKS_RESERVED = 2;
+    const int data_banks = CBUF_BANKS - WEIGHT_BANKS_RESERVED;
+    const int align_in = ((K_seg + 31) / 32) * 32;
+
+    size_t row_bytes;
+    switch (pipeline->npu_type_a) {
+        case rknpu2_configuration::NPU_TYPE_INT4:
+            row_bytes = (size_t)align_in / 2; // 4 bits per element, packed
+            break;
+        case rknpu2_configuration::NPU_TYPE_INT8:
+            row_bytes = (size_t)align_in;
+            break;
+        default: // FP16 / FP32
+            row_bytes = (size_t)align_in * 2;
+            break;
+    }
+    if (row_bytes == 0) return std::numeric_limits<int>::max();
+
+    const size_t cbuf_data_bytes = (size_t)data_banks * (size_t)CBUF_BANK_BYTES;
+    int max_m = (int)(cbuf_data_bytes / row_bytes);
+    if (max_m < 1) max_m = 1;
+    return max_m;
+}
+
 // F8.6a gate: minimum M (src1->ne[1] = q_len) required to route a batched
 // rank-3 mul_mat to the NPU. Decode (M=1) is dominated by per-call B prep
 // overhead and runs faster on CPU; prefill / chunk passes (M >= 16) are
@@ -1725,6 +1763,24 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                         rknpu_log_batched_shape_once(src0, src1, op);
                     }
                     return false;
+                }
+
+                // F8.6b stability cap: F8.6b's flatten asks the NPU for one
+                // matmul of M_total = M * n_heads rows. CBUF can't hold A
+                // larger than max_m rows for the given K, and the librknnrt
+                // 2.3.2 driver crashes silently past that. Reject the op so
+                // it falls back to CPU; F8.6c will replace this with M-tiling.
+                const auto* pipe_for_cap = config.resolve_op_support(src0);
+                if (pipe_for_cap) {
+                    const int K_seg_worst = (int)src0->ne[0];
+                    const int max_m = rknpu_max_m_for_cbuf(pipe_for_cap, K_seg_worst);
+                    const int64_t M_total = src1->ne[1] * src1->ne[2];
+                    if (M_total > max_m) {
+                        if (rknpu_batched_diag_enabled()) {
+                            rknpu_log_batched_shape_once(src0, src1, op);
+                        }
+                        return false;
+                    }
                 }
             }
 

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -52,6 +52,21 @@ static bool rknpu_batched_mm_enabled() {
     return enabled;
 }
 
+// F8.6a gate: minimum M (src1->ne[1] = q_len) required to route a batched
+// rank-3 mul_mat to the NPU. Decode (M=1) is dominated by per-call B prep
+// overhead and runs faster on CPU; prefill / chunk passes (M >= 16) are
+// where the NPU has a shot. Default 16; override with RKNPU_BATCHED_MM_MIN_M.
+// Setting to 0 disables the gate entirely.
+static int rknpu_batched_mm_min_m() {
+    static const int value = []() {
+        const char* v = std::getenv("RKNPU_BATCHED_MM_MIN_M");
+        if (v == nullptr || v[0] == '\0') return 16;
+        const int parsed = std::atoi(v);
+        return parsed >= 0 ? parsed : 16;
+    }();
+    return value;
+}
+
 static void rknpu_log_batched_shape_once(
         const struct ggml_tensor * src0,
         const struct ggml_tensor * src1,
@@ -1666,6 +1681,16 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                 }
                 // dst's head dim must match src1's; we slice both by nb[2].
                 if (op->ne[2] != src1->ne[2]) {
+                    return false;
+                }
+                // F8.6a: gate small-M (decode) shapes off the NPU. Per-call
+                // B-prep on F16 K/V cache slices is more expensive than the
+                // CPU matmul for M=1 and very small M.
+                const int min_m = rknpu_batched_mm_min_m();
+                if (min_m > 0 && (int)src1->ne[1] < min_m) {
+                    if (rknpu_batched_diag_enabled()) {
+                        rknpu_log_batched_shape_once(src0, src1, op);
+                    }
                     return false;
                 }
             }

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -52,6 +52,21 @@ static bool rknpu_batched_mm_enabled() {
     return enabled;
 }
 
+// TST.3 / debug override: when RKNPU_FORCE_DYNAMIC_B=1, graph_compute
+// pretends src0 is never pre-quantized, forcing the dynamic-B path
+// (prepare_b_dynamic_segment) even for tensors that went through
+// set_tensor's pipeline path. Used to exercise dynamic-B from the
+// existing test_mul_mat infrastructure (which always allocates src0 in
+// the test backend's buffer, so set_tensor marks it pre_quantized=true
+// and the static path would otherwise win). Production-safe default off.
+static bool rknpu_force_dynamic_b() {
+    static const bool enabled = []() {
+        const char* v = std::getenv("RKNPU_FORCE_DYNAMIC_B");
+        return v != nullptr && v[0] != '\0' && v[0] != '0';
+    }();
+    return enabled;
+}
+
 // F8.6a gate: minimum M (src1->ne[1] = q_len) required to route a batched
 // rank-3 mul_mat to the NPU. Decode (M=1) is dominated by per-call B prep
 // overhead and runs faster on CPU; prefill / chunk passes (M >= 16) are
@@ -711,7 +726,7 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                 b_domain_id = it->second.iommu_domain_id;
             }
         }
-        const bool use_static_path = src0_is_pre_quantized;
+        const bool use_static_path = src0_is_pre_quantized && !rknpu_force_dynamic_b();
 
         const size_t src1_head_stride = (n_heads > 1) ? (src1->nb[2] / sizeof(float)) : 0;
         const size_t dst_head_stride  = (n_heads > 1) ? (dst->nb[2]  / sizeof(float)) : 0;
@@ -1559,6 +1574,14 @@ static void ggml_backend_rknpu_buffer_get_tensor(ggml_backend_buffer_t buffer, c
 static void ggml_backend_rknpu_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {
     auto * ctx = (ggml_backend_rknpu_buffer_context *)buffer->context;
     std::lock_guard<std::mutex> lock(ctx->mutex);
+
+    // TST.2 follow-up: tensor->data lives in virtual_base and is the source
+    // of truth for get_tensor and the dynamic-B path. Clearing only alloc.mem
+    // would leave stale GGUF bytes visible on read-back. Clear the whole
+    // virtual_base so semantics match the CPU backend's clear.
+    if (ctx->virtual_base) {
+        memset(ctx->virtual_base, value, ctx->total_size);
+    }
 
     for (auto& pair : ctx->tensor_allocs) {
         memset((uint8_t*)pair.second.mem->virt_addr, value, pair.second.size);

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -637,10 +637,23 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
             continue;
         }
 
-        // Using next power of two for M for efficient caching
-        int M_op = M;
-        if (M > 1) {
-            M_op = rknpu2_calibration::next_power_of_two(M);
+        // F8.3: dst (and src1) may carry a head dim ne[2] that broadcasts a
+        // single rank-2 src0 across n_heads sub-matmuls. n_heads=1 collapses
+        // to the original single-matmul path. Detect it early so M_op below
+        // already reflects the flattened head count (F8.6b).
+        const int n_heads = (int)dst->ne[2];
+        GGML_ASSERT(n_heads >= 1 && "dst->ne[2] must be >= 1");
+
+        // F8.6b: flatten heads. Run a single NPU matmul per (k_seg, n_seg)
+        // with M_total = M * n_heads rows of A, instead of one matmul per
+        // head. The NPU sees a bigger A and produces a bigger C in one
+        // submission; we scatter rows back to dst[h] in the collect step.
+        // For n_heads=1 (static path / non-batched dynamic) M_total == M and
+        // the routine is unchanged.
+        const int M_total = M * n_heads;
+        int M_op = M_total;
+        if (M_total > 1) {
+            M_op = rknpu2_calibration::next_power_of_two(M_total);
         }
 
         const auto* pipeline = config.resolve_op_support(src0);
@@ -700,11 +713,6 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
         }
         const bool use_static_path = src0_is_pre_quantized;
 
-        // F8.3: dst (and src1) may carry a head dim ne[2] that broadcasts a
-        // single rank-2 src0 across n_heads sub-matmuls. n_heads=1 collapses
-        // to the original single-matmul path.
-        const int n_heads = (int)dst->ne[2];
-        GGML_ASSERT(n_heads >= 1 && "dst->ne[2] must be >= 1");
         const size_t src1_head_stride = (n_heads > 1) ? (src1->nb[2] / sizeof(float)) : 0;
         const size_t dst_head_stride  = (n_heads > 1) ? (dst->nb[2]  / sizeof(float)) : 0;
 
@@ -847,18 +855,17 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                 }
             }
 
-            // F8.3 head loop: src1/dst can carry a head dim (ne[2] = n_heads)
-            // that broadcasts the rank-2 src0/B across n_heads sub-matmuls.
-            // For static (n_heads=1) this collapses to the original code.
-            // B preparation above already happened once per k_seg and is
-            // amortized across all heads.
+            // F8.6b: heads are flattened into M_total = M * n_heads rows of A.
+            // One NPU matmul per (k_seg, n_seg) handles all heads at once;
+            // collect scatters row (h*M + m) of C back to dst[h][m]. For
+            // n_heads=1 this is identical to the original single-matmul path.
             if (rknpu_batched_diag_enabled() && n_heads > 1 && k_idx == 0) {
                 static std::mutex m;
                 static std::unordered_set<std::string> seen;
                 char key[512];
                 std::snprintf(key, sizeof(key),
-                    "ROUTED static=%d M=%d K=%d N=%d n_heads=%d src0=%s/%s/op=%d/view_src=%p/flags=0x%x src1=%s dst=%s op=%s",
-                    use_static_path ? 1 : 0, M, K, N, n_heads,
+                    "ROUTED static=%d M=%d K=%d N=%d n_heads=%d M_total=%d src0=%s/%s/op=%d/view_src=%p/flags=0x%x src1=%s dst=%s op=%s",
+                    use_static_path ? 1 : 0, M, K, N, n_heads, M_total,
                     ggml_type_name(src0->type),
                     src0->name[0] ? src0->name : "?",
                     (int)src0->op,
@@ -874,179 +881,182 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
             }
             const float* x_base = (const float*)get_tensor_real_ptr(src1);
 
-            for (int h = 0; h < n_heads; ++h) {
-                const float* x = x_base + (size_t)h * src1_head_stride;
-                float* dst_data_h = dst_data + (size_t)h * dst_head_stride;
+            // ===========================================
+            // ========== 2. Preparing A-matrix ==========
+            // ===========================================
+            std::vector<float> scales_A(M_total, 1.0f);
+            {
+                auto cache_key = std::make_tuple(M_op, K_seg_op, (int)pipeline->npu_type_a, b_domain_id);
+                auto& matmul_ctx_0 = matmul_ctxs[0];
 
-                // ===========================================
-                // ========== 2. Preparing A-matrix ==========
-                // ===========================================
-                std::vector<float> scales_A(M, 1.0f);
-                {
-                    auto cache_key = std::make_tuple(M_op, K_seg_op, (int)pipeline->npu_type_a, b_domain_id);
-                    auto& matmul_ctx_0 = matmul_ctxs[0];
+                // Getting A-buffer from cache (sized M_op × K_seg_op via matmul ctx)
+                mem_A_shared = get_tensor_buffer(backend_ctx, matmul_ctx_0->ctx, matmul_ctx_0->io_attr.A.size, cache_key, backend_ctx->a_buffer_cache);
+                if (!mem_A_shared) return GGML_STATUS_FAILED;
 
-                    // Getting A-buffer from cache
-                    mem_A_shared = get_tensor_buffer(backend_ctx, matmul_ctx_0->ctx, matmul_ctx_0->io_attr.A.size, cache_key, backend_ctx->a_buffer_cache);
-                    if (!mem_A_shared) return GGML_STATUS_FAILED;
+                const int row_stride = (int)(src1->nb[1] / sizeof(float));
+                void* dst_base = mem_A_shared->virt_addr;
 
-                    const int row_stride = (int)(src1->nb[1] / sizeof(float));
-                    void* dst_base = mem_A_shared->virt_addr;
+                #pragma omp parallel for
+                for (int row_idx = 0; row_idx < M_total; ++row_idx) {
+                    const int h = (n_heads > 1) ? (row_idx / M) : 0;
+                    const int m = (n_heads > 1) ? (row_idx - h * M) : row_idx;
+                    const float* src_row = x_base
+                        + (size_t)h * src1_head_stride
+                        + (size_t)m * row_stride;
+                    std::vector<float> ready_row(K_seg_op);
 
-                    #pragma omp parallel for
-                    for (int m = 0; m < M; ++m) {
-                        const float* src_row = x + (size_t)m * row_stride;
-                        std::vector<float> ready_row(K_seg_op);
+                    // Applying Hadamard Transform
+                    if (is_hadamard) {
+                        std::vector<float> signed_row(K);
+                        std::vector<float> full_hadamard_row(K_op);
+                        for(int k=0; k<K; ++k) signed_row[k] = src_row[k] * s_vec[k];
+                        rknpu2_calibration::hadamard_transform(full_hadamard_row.data(), signed_row.data(), K, K_op);
 
-                        // Applying Hadamard Transform
-                        if (is_hadamard) {
-                            std::vector<float> signed_row(K);
-                            std::vector<float> full_hadamard_row(K_op);
-                            for(int k=0; k<K; ++k) signed_row[k] = src_row[k] * s_vec[k];
-                            rknpu2_calibration::hadamard_transform(full_hadamard_row.data(), signed_row.data(), K, K_op);
-
-                            memcpy(ready_row.data(), full_hadamard_row.data() + k_seg.offset_k, K_seg_op * sizeof(float));
-                        } else {
-                            memcpy(ready_row.data(), src_row + k_seg.offset_k, K_seg_op * sizeof(float));
-                        }
-
-                        // Handling types and quantizations
-                        if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_FP16) {
-                            uint16_t* dst_ptr = (uint16_t*)dst_base;
-                            uint16_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
-                            rknpu2_quantization::convert_fp32_to_fp16(ready_row.data(), dst_row, K_seg_op);
-                        }
-                        else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT8) {
-                            float amax_m = 0.0f;
-                            for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
-                            scales_A[m] = amax_m / 127.0f;
-
-                            int8_t* dst_ptr = (int8_t*)dst_base;
-                            int8_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
-                            rknpu2_quantization::quantize_fp32_to_int8(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
-                        }
-                        else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT4) {
-                            float amax_m = 0.0f;
-                            for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
-                            scales_A[m] = amax_m / 7.0f;
-
-                            uint8_t* dst_ptr = (uint8_t*)dst_base;
-                            uint8_t* dst_row = dst_ptr + (size_t)m * (K_seg_op / 2);
-                            rknpu2_quantization::quantize_fp32_to_int4_packed(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
-                        }
+                        memcpy(ready_row.data(), full_hadamard_row.data() + k_seg.offset_k, K_seg_op * sizeof(float));
+                    } else {
+                        memcpy(ready_row.data(), src_row + k_seg.offset_k, K_seg_op * sizeof(float));
                     }
 
-                    // Assigning A-matrix to all contexts for the parallel execution
-                    for (size_t idx = 0; idx < num_active_segments; idx++) {
-                        RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctxs[idx]->ctx, mem_A_shared.get(), &matmul_ctxs[idx]->io_attr.A), "set_io_mem A for core");
+                    // Handling types and quantizations (write to A row `row_idx`)
+                    if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_FP16) {
+                        uint16_t* dst_ptr = (uint16_t*)dst_base;
+                        uint16_t* dst_row = dst_ptr + (size_t)row_idx * K_seg_op;
+                        rknpu2_quantization::convert_fp32_to_fp16(ready_row.data(), dst_row, K_seg_op);
                     }
+                    else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT8) {
+                        float amax_m = 0.0f;
+                        for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
+                        scales_A[row_idx] = amax_m / 127.0f;
 
-                    RKNN_CHECK(rknn_mem_sync(matmul_ctxs[0]->ctx, mem_A_shared.get(), RKNN_MEMORY_SYNC_TO_DEVICE), "sync A TO_DEVICE");
-                }
+                        int8_t* dst_ptr = (int8_t*)dst_base;
+                        int8_t* dst_row = dst_ptr + (size_t)row_idx * K_seg_op;
+                        rknpu2_quantization::quantize_fp32_to_int8(ready_row.data(), dst_row, K_seg_op, scales_A[row_idx]);
+                    }
+                    else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT4) {
+                        float amax_m = 0.0f;
+                        for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
+                        scales_A[row_idx] = amax_m / 7.0f;
 
-                // ===========================================
-                // ========== 3. Preparing C-matrix ==========
-                // ===========================================
-                {
-                    for (size_t idx = 0; idx < num_active_segments; idx++) {
-                        auto& matmul_ctx = matmul_ctxs[idx];
-                        auto cache_key = std::make_tuple(M_op, active_n_segments[idx].size_n, active_n_segments[idx].core_id, (int)pipeline->npu_type_c, b_domain_id);
-
-                        // Getting C-buffer from cache
-                        mem_C_segments[idx] = get_tensor_buffer(backend_ctx, matmul_ctx->ctx, matmul_ctx->io_attr.C.size, cache_key, backend_ctx->c_buffer_cache);
-                        if (!mem_C_segments[idx]) return GGML_STATUS_FAILED;
-
-                        // Assigning C-matrix to current context for the parallel execution
-                        RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctx->ctx, mem_C_segments[idx].get(), &matmul_ctx->io_attr.C), "set_io_mem C");
+                        uint8_t* dst_ptr = (uint8_t*)dst_base;
+                        uint8_t* dst_row = dst_ptr + (size_t)row_idx * (K_seg_op / 2);
+                        rknpu2_quantization::quantize_fp32_to_int4_packed(ready_row.data(), dst_row, K_seg_op, scales_A[row_idx]);
                     }
                 }
 
-                // ==========================================
-                // ========== 4. Running operation ==========
-                // ==========================================
-                {
-                    #pragma omp parallel for num_threads(num_active_segments)
-                    for (size_t idx = 0; idx < num_active_segments; idx++) {
-                        int ret = rknn_matmul_run(matmul_ctxs[idx]->ctx);
-                        if (ret != RKNN_SUCC) {
-                            // Handle error
-                        }
-                    }
+                // Assigning A-matrix to all contexts for the parallel execution
+                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                    RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctxs[idx]->ctx, mem_A_shared.get(), &matmul_ctxs[idx]->io_attr.A), "set_io_mem A for core");
                 }
 
-                // ===========================================
-                // ========== 5. Collecting results ==========
-                // ===========================================
-                {
-                    for (size_t idx = 0; idx < num_active_segments; idx++) {
-                        RKNN_CHECK(rknn_mem_sync(matmul_ctxs[idx]->ctx, mem_C_segments[idx].get(), RKNN_MEMORY_SYNC_FROM_DEVICE), "sync C FROM_DEVICE");
+                RKNN_CHECK(rknn_mem_sync(matmul_ctxs[0]->ctx, mem_A_shared.get(), RKNN_MEMORY_SYNC_TO_DEVICE), "sync A TO_DEVICE");
+            }
+
+            // ===========================================
+            // ========== 3. Preparing C-matrix ==========
+            // ===========================================
+            {
+                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                    auto& matmul_ctx = matmul_ctxs[idx];
+                    auto cache_key = std::make_tuple(M_op, active_n_segments[idx].size_n, active_n_segments[idx].core_id, (int)pipeline->npu_type_c, b_domain_id);
+
+                    // Getting C-buffer from cache
+                    mem_C_segments[idx] = get_tensor_buffer(backend_ctx, matmul_ctx->ctx, matmul_ctx->io_attr.C.size, cache_key, backend_ctx->c_buffer_cache);
+                    if (!mem_C_segments[idx]) return GGML_STATUS_FAILED;
+
+                    // Assigning C-matrix to current context for the parallel execution
+                    RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctx->ctx, mem_C_segments[idx].get(), &matmul_ctx->io_attr.C), "set_io_mem C");
+                }
+            }
+
+            // ==========================================
+            // ========== 4. Running operation ==========
+            // ==========================================
+            {
+                #pragma omp parallel for num_threads(num_active_segments)
+                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                    int ret = rknn_matmul_run(matmul_ctxs[idx]->ctx);
+                    if (ret != RKNN_SUCC) {
+                        // Handle error
                     }
+                }
+            }
 
-                    const float hadamard_divisor = pipeline->use_hadamard ? (float)K_op : 1.0f;
+            // ===========================================
+            // ========== 5. Collecting results ==========
+            // ===========================================
+            {
+                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                    RKNN_CHECK(rknn_mem_sync(matmul_ctxs[idx]->ctx, mem_C_segments[idx].get(), RKNN_MEMORY_SYNC_FROM_DEVICE), "sync C FROM_DEVICE");
+                }
 
-                    #pragma omp parallel for
-                    for (int m = 0; m < M; m++) {
-                        // Handling types and quantizations
-                        switch (pipeline->npu_type_c) {
-                            case rknpu2_configuration::NPU_TYPE_FP32: {
-                                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
+                const float hadamard_divisor = pipeline->use_hadamard ? (float)K_op : 1.0f;
 
-                                    int N_offset = active_n_segments[idx].offset_n;
-                                    int N_segment = active_n_segments[idx].size_n;
-                                    float* src_segment_base = (float*)mem_C_segments[idx]->virt_addr;
-                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
-                                    float* src_ptr = src_segment_base + (size_t)m * N_segment;
+                #pragma omp parallel for
+                for (int row_idx = 0; row_idx < M_total; row_idx++) {
+                    const int h = (n_heads > 1) ? (row_idx / M) : 0;
+                    const int m = (n_heads > 1) ? (row_idx - h * M) : row_idx;
+                    float* dst_data_h = dst_data + (size_t)h * dst_head_stride;
 
-                                    for(int n=0; n<N_segment; ++n) {
-                                        dst_ptr[n] += src_ptr[n] * dequant_scale;
-                                    }
+                    // Handling types and quantizations
+                    switch (pipeline->npu_type_c) {
+                        case rknpu2_configuration::NPU_TYPE_FP32: {
+                            for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                float dequant_scale = (scales_A[row_idx] * scale_B) / hadamard_divisor;
+
+                                int N_offset = active_n_segments[idx].offset_n;
+                                int N_segment = active_n_segments[idx].size_n;
+                                float* src_segment_base = (float*)mem_C_segments[idx]->virt_addr;
+                                float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                float* src_ptr = src_segment_base + (size_t)row_idx * N_segment;
+
+                                for(int n=0; n<N_segment; ++n) {
+                                    dst_ptr[n] += src_ptr[n] * dequant_scale;
                                 }
-                                break;
                             }
-
-                            case rknpu2_configuration::NPU_TYPE_INT32: {
-                                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
-
-                                    int N_offset = active_n_segments[idx].offset_n;
-                                    int N_segment = active_n_segments[idx].size_n;
-                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
-                                    int32_t* src_ptr = (int32_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
-
-                                    for(int n=0; n<N_segment; ++n) {
-                                        dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
-                                    }
-                                }
-                                break;
-                            }
-
-                            case rknpu2_configuration::NPU_TYPE_INT16: {
-                                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
-
-                                    int N_offset = active_n_segments[idx].offset_n;
-                                    int N_segment = active_n_segments[idx].size_n;
-                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
-                                    int16_t* src_ptr = (int16_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
-
-                                    for(int n=0; n<N_segment; ++n) {
-                                        dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
-                                    }
-                                }
-                                break;
-                            }
-
-                            default:
-                                // This should not be reached if config is correct
-                                break;
+                            break;
                         }
+
+                        case rknpu2_configuration::NPU_TYPE_INT32: {
+                            for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                float dequant_scale = (scales_A[row_idx] * scale_B) / hadamard_divisor;
+
+                                int N_offset = active_n_segments[idx].offset_n;
+                                int N_segment = active_n_segments[idx].size_n;
+                                float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                int32_t* src_ptr = (int32_t*)mem_C_segments[idx]->virt_addr + (size_t)row_idx * N_segment;
+
+                                for(int n=0; n<N_segment; ++n) {
+                                    dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
+                                }
+                            }
+                            break;
+                        }
+
+                        case rknpu2_configuration::NPU_TYPE_INT16: {
+                            for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                float dequant_scale = (scales_A[row_idx] * scale_B) / hadamard_divisor;
+
+                                int N_offset = active_n_segments[idx].offset_n;
+                                int N_segment = active_n_segments[idx].size_n;
+                                float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                int16_t* src_ptr = (int16_t*)mem_C_segments[idx]->virt_addr + (size_t)row_idx * N_segment;
+
+                                for(int n=0; n<N_segment; ++n) {
+                                    dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
+                                }
+                            }
+                            break;
+                        }
+
+                        default:
+                            // This should not be reached if config is correct
+                            break;
                     }
                 }
-            } // end head loop
+            }
         }
     }
 

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -27,6 +27,8 @@
 #include <sstream>
 #include <cstdio>
 #include <unordered_set>
+#include <atomic>
+#include <cstdint>
 
 #define UNUSED(x) (void)(x)
 
@@ -50,6 +52,48 @@ static bool rknpu_batched_mm_enabled() {
         return v != nullptr && v[0] != '\0' && v[0] != '0';
     }();
     return enabled;
+}
+
+// F8.5 route counters: per-process atomic stats so any bench / PPL run can
+// answer "where did the batched mul_mat ops actually go?" Used by the codex
+// review criteria. Printed by the backend's free hook (one summary per
+// backend lifetime); a diagnostic env flag also dumps them into stderr.
+struct RknpuRouteStats {
+    std::atomic<uint64_t> mul_mat_total{0};
+    std::atomic<uint64_t> rejected_rank{0};       // ne[3]>1, etc.
+    std::atomic<uint64_t> rejected_batched_off{0}; // RKNPU_BATCHED_MM_ENABLE=0
+    std::atomic<uint64_t> rejected_min_m{0};
+    std::atomic<uint64_t> rejected_cbuf{0};
+    std::atomic<uint64_t> rejected_other{0};      // pipeline/align/contig/...
+    std::atomic<uint64_t> accepted_rank2{0};
+    std::atomic<uint64_t> accepted_batched{0};
+    std::atomic<uint64_t> dispatched_static{0};
+    std::atomic<uint64_t> dispatched_dynamic{0};
+};
+
+static RknpuRouteStats& rknpu_route_stats() {
+    static RknpuRouteStats s;
+    return s;
+}
+
+static void rknpu_print_route_stats(const char* label) {
+    auto& s = rknpu_route_stats();
+    std::fprintf(stderr,
+        "RKNPU_ROUTE_STATS %s: mul_mat_total=%lu "
+        "rejected_rank=%lu rejected_batched_off=%lu rejected_min_m=%lu rejected_cbuf=%lu rejected_other=%lu "
+        "accepted_rank2=%lu accepted_batched=%lu "
+        "dispatched_static=%lu dispatched_dynamic=%lu\n",
+        label,
+        (unsigned long)s.mul_mat_total.load(),
+        (unsigned long)s.rejected_rank.load(),
+        (unsigned long)s.rejected_batched_off.load(),
+        (unsigned long)s.rejected_min_m.load(),
+        (unsigned long)s.rejected_cbuf.load(),
+        (unsigned long)s.rejected_other.load(),
+        (unsigned long)s.accepted_rank2.load(),
+        (unsigned long)s.accepted_batched.load(),
+        (unsigned long)s.dispatched_static.load(),
+        (unsigned long)s.dispatched_dynamic.load());
 }
 
 // TST.3 / debug override: when RKNPU_FORCE_DYNAMIC_B=1, graph_compute
@@ -610,6 +654,9 @@ static const char * ggml_backend_rknpu_name(ggml_backend_t backend) {
 }
 
 static void ggml_backend_rknpu_free(ggml_backend_t backend) {
+    // F8.5 route counter dump: print one summary per backend lifetime so
+    // benches/PPL runs can verify what actually ran on the NPU vs CPU.
+    rknpu_print_route_stats("backend_free");
     ggml_backend_rknpu_context * ctx = (ggml_backend_rknpu_context *)backend->context;
     delete ctx;
     delete backend;
@@ -765,6 +812,13 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
             }
         }
         const bool use_static_path = src0_is_pre_quantized && !rknpu_force_dynamic_b();
+
+        // F8.5 route counter: which path actually ran the matmul on the NPU.
+        if (use_static_path) {
+            rknpu_route_stats().dispatched_static.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            rknpu_route_stats().dispatched_dynamic.fetch_add(1, std::memory_order_relaxed);
+        }
 
         const size_t src1_head_stride = (n_heads > 1) ? (src1->nb[2] / sizeof(float)) : 0;
         const size_t dst_head_stride  = (n_heads > 1) ? (dst->nb[2]  / sizeof(float)) : 0;
@@ -1728,6 +1782,8 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
         case GGML_OP_MUL_MAT: {
             const struct ggml_tensor * src0 = op->src[0]; // Weights / runtime B
             const struct ggml_tensor * src1 = op->src[1]; // Activations
+            auto& stats = rknpu_route_stats();
+            stats.mul_mat_total.fetch_add(1, std::memory_order_relaxed);
 
             // src0 is always rank-2 here. src1 / op may be rank-3 (broadcast
             // over n_head_q) when F8.3 is enabled. ne[3] must always be 1.
@@ -1740,6 +1796,7 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                 if (rknpu_batched_diag_enabled()) {
                     rknpu_log_batched_shape_once(src0, src1, op);
                 }
+                stats.rejected_rank.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
@@ -1748,10 +1805,12 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                     if (rknpu_batched_diag_enabled()) {
                         rknpu_log_batched_shape_once(src0, src1, op);
                     }
+                    stats.rejected_batched_off.fetch_add(1, std::memory_order_relaxed);
                     return false;
                 }
                 // dst's head dim must match src1's; we slice both by nb[2].
                 if (op->ne[2] != src1->ne[2]) {
+                    stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                     return false;
                 }
                 // F8.6a: gate small-M (decode) shapes off the NPU. Per-call
@@ -1762,6 +1821,7 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                     if (rknpu_batched_diag_enabled()) {
                         rknpu_log_batched_shape_once(src0, src1, op);
                     }
+                    stats.rejected_min_m.fetch_add(1, std::memory_order_relaxed);
                     return false;
                 }
 
@@ -1779,6 +1839,7 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                         if (rknpu_batched_diag_enabled()) {
                             rknpu_log_batched_shape_once(src0, src1, op);
                         }
+                        stats.rejected_cbuf.fetch_add(1, std::memory_order_relaxed);
                         return false;
                     }
                 }
@@ -1787,51 +1848,65 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
             // Searching for available hardware pipeline for this tensor
             const auto* pipeline = config.resolve_op_support(src0);
             if (!pipeline) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
             // Rejecting zero-dimension ops
             if (src0->ne[0] == 0 || src0->ne[1] == 0 ||
                 src1->ne[0] == 0 || src1->ne[1] == 0) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
             // Checking if activation type matches the supported operation
             if (src1->type != GGML_TYPE_F32) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
             // Checking for K alignment
             if (src0->ne[0] % pipeline->k_align != 0) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
             // Checking for N alignment
             if (src0->ne[1] % pipeline->n_align != 0) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
 
             // Checking for exact dimensions
             if (src1->ne[0] != src0->ne[0]) {
-                 return false;
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
+                return false;
             }
 
             // src0 must be contiguous (we read it row-major in dequantize_row).
             // For batched src1 we only require contiguous rows so permuted
             // attention Q (post permute(0,2,1,3)) is acceptable.
             if (!ggml_is_contiguous(src0)) {
+                stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                 return false;
             }
             if (batched_shape) {
                 if (!ggml_is_contiguous_rows(src1)) {
+                    stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                     return false;
                 }
             } else {
                 if (!ggml_is_contiguous(src1)) {
+                    stats.rejected_other.fetch_add(1, std::memory_order_relaxed);
                     return false;
                 }
             }
 
+            if (batched_shape) {
+                stats.accepted_batched.fetch_add(1, std::memory_order_relaxed);
+            } else {
+                stats.accepted_rank2.fetch_add(1, std::memory_order_relaxed);
+            }
             return true;
         }
         default:

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -408,6 +408,13 @@ struct ggml_backend_rknpu_context {
     // C-matrices cache (M, N, core_id, npu_type_c, domain_id)
     std::unordered_map<std::tuple<int, int, int, int, int>, std::shared_ptr<rknn_tensor_mem>, TupleHasher> c_buffer_cache;
 
+    // F8.2 dynamic-B path: matmul ctx cache keyed only by shape (no tensor_id/offset),
+    // since for dynamic B we re-bind the B memory on every call.
+    std::unordered_map<std::tuple<int, int, int, int, int, int>, std::shared_ptr<rknpu_matmul_context>, TupleHasher> dynamic_matmul_ctx_cache;
+
+    // F8.2 dynamic-B path: per-shape DMA buffer cache for B (re-quantized in-place per call).
+    std::unordered_map<std::tuple<int, int, int, int, int, int>, std::shared_ptr<rknn_tensor_mem>, TupleHasher> b_dynamic_buffer_cache;
+
     std::shared_ptr<rknpu_matmul_context> get_matmul_ctx(uintptr_t tensor_id, size_t offset, int M, int K, int N, int core_id, rknn_matmul_type type, int32_t domain_id) {
         std::lock_guard<std::mutex> lock(mutex);
 
@@ -438,8 +445,71 @@ struct ggml_backend_rknpu_context {
         matmul_ctx_cache[key] = ctx;
         return ctx;
     }
+
+    // F8.2 dynamic-B variant of get_matmul_ctx. Same RKNN ctx setup as the
+    // static path, but cached purely by shape so different src0 tensors that
+    // share the same (M, K, N, core, type, domain) reuse the same context.
+    std::shared_ptr<rknpu_matmul_context> get_dynamic_matmul_ctx(int M, int K, int N, int core_id, rknn_matmul_type type, int32_t domain_id) {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        auto key = std::make_tuple(M, K, N, core_id, (int)type, (int)domain_id);
+        auto it = dynamic_matmul_ctx_cache.find(key);
+        if (it != dynamic_matmul_ctx_cache.end()) {
+            return it->second;
+        }
+
+        auto ctx = std::make_shared<rknpu_matmul_context>(M, K, N, type, domain_id);
+        if (ctx->ctx == 0) {
+            return nullptr;
+        }
+
+        rknn_core_mask core_mask;
+        switch (core_id) {
+            case 0: core_mask = RKNN_NPU_CORE_0; break;
+            case 1: core_mask = RKNN_NPU_CORE_1; break;
+            case 2: core_mask = RKNN_NPU_CORE_2; break;
+            default: core_mask = RKNN_NPU_CORE_AUTO; break;
+        }
+
+        int ret = rknn_matmul_set_core_mask(ctx->ctx, core_mask);
+        if (ret != RKNN_SUCC) {
+            // Handle error
+        }
+
+        dynamic_matmul_ctx_cache[key] = ctx;
+        return ctx;
+    }
 };
 
+
+// F8.2 forward declarations: helpers for the dynamic-B path live further down
+// the file (next to the matching set_tensor helpers); graph_compute needs them
+// before they are defined.
+static const char * ggml_backend_rknpu_buffer_type_get_name(ggml_backend_buffer_type_t buft);
+static void dequantize_row(
+    const struct ggml_tensor * tensor, const void * raw_data,
+    int n, int K, float * row_out);
+static void pack_native(
+    uint8_t* dst, const uint8_t* src,
+    int K_total, int k_offset, int k_segment, int k_align,
+    int N_total, int n_offset, int n_segment, int n_align,
+    int element_bits);
+static float prepare_b_dynamic_segment(
+    const struct ggml_tensor * src0, const void * src0_raw,
+    int K, int N, int K_op,
+    const struct MatrixSegmentK & k_seg,
+    const struct MatrixSegmentN & n_seg,
+    const rknpu2_configuration::Rknpu2HardwarePipeline * pipeline,
+    const float * s_vec_data,
+    uint8_t * dst_dma_ptr);
+
+// F8.2: identify whether a tensor is backed by the RKNPU buffer type. We use
+// the static get_name function pointer as the discriminator — comparing to a
+// local-static buffer_type instance would require exposing it across functions.
+static bool is_rknpu_buffer(const struct ggml_tensor * tensor) {
+    if (!tensor || !tensor->buffer || !tensor->buffer->buft) return false;
+    return tensor->buffer->buft->iface.get_name == ggml_backend_rknpu_buffer_type_get_name;
+}
 
 //
 // Backend
@@ -568,15 +638,22 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
         std::shared_ptr<rknn_tensor_mem> mem_A_shared;
         std::vector<std::shared_ptr<rknn_tensor_mem>> mem_C_segments(num_active_segments);
 
-        // Acquiring the B-matrix buffer
-        ggml_backend_buffer_t src0_buffer = src0->buffer;
-        auto* src0_buf_ctx = (ggml_backend_rknpu_buffer_context*)src0_buffer->context;
-        size_t tensor_offset_in_virtual = (uintptr_t)src0->data - (uintptr_t)src0_buf_ctx->virtual_base;
+        // F8.2: split static (pre-quantized weight) vs dynamic (per-call src0)
+        // path. Today's supports_op only routes the static case here; the
+        // dynamic branch becomes reachable once F8.3 relaxes the rank>2 guard.
+        const bool src0_in_rknpu = is_rknpu_buffer(src0);
 
+        // Acquiring the B-matrix buffer (static path only)
+        ggml_backend_rknpu_buffer_context* src0_buf_ctx = nullptr;
+        size_t tensor_offset_in_virtual = 0;
         int32_t b_domain_id = 0;
         int tensor_fd = -1;
         void* tensor_virt_addr = nullptr;
-        {
+        if (src0_in_rknpu) {
+            ggml_backend_buffer_t src0_buffer = src0->buffer;
+            src0_buf_ctx = (ggml_backend_rknpu_buffer_context*)src0_buffer->context;
+            tensor_offset_in_virtual = (uintptr_t)src0->data - (uintptr_t)src0_buf_ctx->virtual_base;
+
             std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
             auto it = src0_buf_ctx->tensor_allocs.find(tensor_offset_in_virtual);
             GGML_ASSERT(it != src0_buf_ctx->tensor_allocs.end() && "B-matrix RKNN buffer not found");
@@ -586,29 +663,47 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
             b_domain_id = it->second.iommu_domain_id;
         }
 
-        // Cleaning the C-matrix buffer
-        float* dst_data = (float*)get_tensor_real_ptr(dst);
+        // Cleaning the C-matrix buffer. dst lives in the RKNPU buffer when src0
+        // does (static); in the dynamic path dst is a normal CPU tensor.
+        float* dst_data = src0_in_rknpu ? (float*)get_tensor_real_ptr(dst) : (float*)dst->data;
         memset(dst_data, 0, (size_t)M * N * sizeof(float));
 
         // Acquiring the Hadamard vector
         std::vector<float> s_vec;
         if (is_hadamard) {
-            std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
-            auto it = src0_buf_ctx->hadamard_s_vectors.find(src0);
-            GGML_ASSERT(it != src0_buf_ctx->hadamard_s_vectors.end() && "Hadamard 's' vector not found");
-            s_vec = it->second;
+            if (src0_in_rknpu) {
+                std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
+                auto it = src0_buf_ctx->hadamard_s_vectors.find(src0);
+                GGML_ASSERT(it != src0_buf_ctx->hadamard_s_vectors.end() && "Hadamard 's' vector not found");
+                s_vec = it->second;
+            } else {
+                // Dynamic path: regenerate deterministically from src0 ptr,
+                // matching the seed scheme used in buffer_set_tensor.
+                s_vec.assign(K_op, 1.0f);
+                std::mt19937 gen(reinterpret_cast<uintptr_t>(src0));
+                std::uniform_int_distribution<int> distrib(0, 1);
+                for (int k = 0; k < K_op; ++k) {
+                    s_vec[k] = (distrib(gen) == 0) ? -1.0f : 1.0f;
+                }
+            }
         }
 
-        // Calculating the B-matrix scale
+        // Calculating the B-matrix scale. Static path looks the grid up from
+        // the buffer ctx; dynamic path fills it inline below as we quantize
+        // each (k_seg, n_seg) block.
         std::vector<float> scales_B_grid;
-        if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT8 || pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) {
-            std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
-            auto it = src0_buf_ctx->quantized_tensor_scales.find(src0);
-            GGML_ASSERT(it != src0_buf_ctx->quantized_tensor_scales.end() && "Quantized scales grid not found");
-            scales_B_grid = it->second;
+        if (src0_in_rknpu) {
+            if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT8 || pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) {
+                std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
+                auto it = src0_buf_ctx->quantized_tensor_scales.find(src0);
+                GGML_ASSERT(it != src0_buf_ctx->quantized_tensor_scales.end() && "Quantized scales grid not found");
+                scales_B_grid = it->second;
+            }
+        } else {
+            scales_B_grid.assign(all_k_segments.size() * num_active_segments, 1.0f);
         }
 
-        // Calculating tensor packed size
+        // Calculating tensor packed size (only used by the static FD-mapped layout)
         size_t type_size_packed = 0;
         if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_FP16) type_size_packed = 2;
         else if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT8) type_size_packed = 1;
@@ -624,10 +719,14 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
             // ===========================================
             for (const auto& n_seg : all_n_segments) {
                 for (size_t idx = 0; idx < num_active_segments; ++idx) {
-                    if (active_n_segments[idx].offset_n == n_seg.offset_n) {
+                    if (active_n_segments[idx].offset_n != n_seg.offset_n) continue;
+
+                    if (src0_in_rknpu) {
+                        // Static path: B was pre-quantized + packed at set_tensor
+                        // time and lives at a known offset inside the FD-mapped
+                        // tensor blob; bind once via create_mem_from_fd.
                         size_t offset_in_dma = current_offset_in_tensor;
 
-                        // Getting matmul context from cache
                         matmul_ctxs[idx] = backend_ctx->get_matmul_ctx(
                             (uintptr_t)tensor_virt_addr, offset_in_dma, M_op, K_seg_op, n_seg.size_n,
                             n_seg.core_id, matmul_type, b_domain_id
@@ -636,7 +735,6 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
 
                         auto& matmul_ctx = matmul_ctxs[idx];
 
-                        // Assigning B-matrix only once to reduce computation overhead
                         if (!matmul_ctx->b_bound) {
                             size_t segment_size_bytes = matmul_ctx->io_attr.B.size;
 
@@ -656,11 +754,47 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
 
                             matmul_ctx->b_bound = true;
                         }
-                        break;
+                    } else {
+                        // F8.2 dynamic-B path: src0 is a runtime tensor (e.g.
+                        // K/V from CPU backend in attention K·Q^T), not a
+                        // pre-quantized weight. Reuse a shape-keyed matmul ctx
+                        // and a shape-keyed DMA buffer, but re-fill the B
+                        // contents and re-bind every call.
+                        const int32_t domain_id = 0;
+
+                        matmul_ctxs[idx] = backend_ctx->get_dynamic_matmul_ctx(
+                            M_op, K_seg_op, n_seg.size_n,
+                            n_seg.core_id, matmul_type, domain_id
+                        );
+                        if (!matmul_ctxs[idx] || matmul_ctxs[idx]->ctx == 0) return GGML_STATUS_FAILED;
+
+                        auto& matmul_ctx = matmul_ctxs[idx];
+
+                        auto b_key = std::make_tuple(
+                            M_op, K_seg_op, n_seg.size_n, n_seg.core_id,
+                            (int)pipeline->npu_type_b, (int)domain_id);
+                        auto mem_B = get_tensor_buffer(
+                            backend_ctx, matmul_ctx->ctx, matmul_ctx->io_attr.B.size,
+                            b_key, backend_ctx->b_dynamic_buffer_cache);
+                        if (!mem_B) return GGML_STATUS_FAILED;
+                        matmul_ctx->mem_B = mem_B;
+
+                        const float * s_vec_ptr = is_hadamard ? s_vec.data() : nullptr;
+                        const float block_scale = prepare_b_dynamic_segment(
+                            src0, src0->data,
+                            K, N, K_op,
+                            k_seg, n_seg, pipeline,
+                            s_vec_ptr,
+                            (uint8_t*)mem_B->virt_addr);
+                        scales_B_grid[k_idx * num_active_segments + idx] = block_scale;
+
+                        RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctx->ctx, mem_B.get(), &matmul_ctx->io_attr.B), "set_io_mem B dynamic");
+                        RKNN_CHECK(rknn_mem_sync(matmul_ctx->ctx, mem_B.get(), RKNN_MEMORY_SYNC_TO_DEVICE), "sync B dynamic TO_DEVICE");
                     }
+                    break;
                 }
 
-                if (n_seg.size_n > 0) {
+                if (src0_in_rknpu && n_seg.size_n > 0) {
                     current_offset_in_tensor += type_size_packed > 0 ? (size_t)n_seg.size_n * K_seg_op * type_size_packed : (size_t)n_seg.size_n * K_seg_op / 2;
                 }
             }
@@ -1102,6 +1236,88 @@ static size_t pack_tensor_segment(
                 element_bits);
 
     return segment_packed_size;
+}
+
+// F8.2 dynamic-B helper: dequantize one (k_seg, n_seg) tile from src0 directly
+// (no buffer-context lookup), apply Hadamard if requested, compute the block
+// scale, quantize and pack into the supplied DMA buffer. Returns the block
+// scale so the caller can record it in scales_B_grid for dequantization in
+// the result-collection stage. Mirrors the math in buffer_set_tensor so the
+// dynamic and static paths stay numerically equivalent.
+static float prepare_b_dynamic_segment(
+    const struct ggml_tensor * src0, const void * src0_raw,
+    int K, int N, int K_op,
+    const MatrixSegmentK & k_seg,
+    const MatrixSegmentN & n_seg,
+    const rknpu2_configuration::Rknpu2HardwarePipeline * pipeline,
+    const float * s_vec_data,
+    uint8_t * dst_dma_ptr)
+{
+    const bool use_hadamard = (s_vec_data != nullptr);
+    const size_t seg_elements = (size_t)n_seg.size_n * k_seg.size_k;
+
+    std::vector<float> seg_fp32(seg_elements, 0.0f);
+
+    #pragma omp parallel for
+    for (int i = 0; i < n_seg.size_n; ++i) {
+        const int global_n = n_seg.offset_n + i;
+        if (global_n >= N) {
+            std::memset(&seg_fp32[(size_t)i * k_seg.size_k], 0, k_seg.size_k * sizeof(float));
+            continue;
+        }
+
+        std::vector<float> row_raw(K);
+        std::vector<float> row_processed(K_op, 0.0f);
+
+        dequantize_row(src0, src0_raw, global_n, K, row_raw.data());
+
+        if (use_hadamard) {
+            std::vector<float> signed_row(K);
+            for (int k = 0; k < K; ++k) signed_row[k] = row_raw[k] * s_vec_data[k];
+            rknpu2_calibration::hadamard_transform(row_processed.data(), signed_row.data(), K, K_op);
+        } else {
+            std::memcpy(row_processed.data(), row_raw.data(), K * sizeof(float));
+        }
+
+        std::memcpy(&seg_fp32[(size_t)i * k_seg.size_k],
+                    &row_processed[k_seg.offset_k],
+                    k_seg.size_k * sizeof(float));
+    }
+
+    float block_scale = 1.0f;
+    if (pipeline->npu_type_b != rknpu2_configuration::NPU_TYPE_FP16) {
+        float amax = 0.0f;
+        if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) {
+            amax = rknpu2_calibration::calculate_entropy_amax(seg_fp32.data(), seg_fp32.size());
+        } else {
+            for (float v : seg_fp32) amax = std::max(amax, std::abs(v));
+        }
+        const float quant_divisor = (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) ? 7.0f : 127.0f;
+        block_scale = (amax == 0.0f) ? 1.0f : amax / quant_divisor;
+    }
+
+    std::vector<uint8_t> seg_npu;
+    int element_bits = 0;
+    if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_FP16) {
+        element_bits = 16;
+        seg_npu.resize(seg_elements * 2);
+        rknpu2_quantization::convert_fp32_to_fp16(seg_fp32.data(), (uint16_t*)seg_npu.data(), seg_elements);
+    } else if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT8) {
+        element_bits = 8;
+        seg_npu.resize(seg_elements);
+        rknpu2_quantization::quantize_fp32_to_int8(seg_fp32.data(), (int8_t*)seg_npu.data(), seg_elements, block_scale);
+    } else if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) {
+        element_bits = 4;
+        seg_npu.resize(seg_elements / 2);
+        rknpu2_quantization::quantize_fp32_to_int4_packed(seg_fp32.data(), seg_npu.data(), seg_elements, block_scale);
+    }
+
+    pack_native(dst_dma_ptr, seg_npu.data(),
+                k_seg.size_k, 0, k_seg.size_k, pipeline->k_align,
+                n_seg.size_n, 0, n_seg.size_n, pipeline->n_align,
+                element_bits);
+
+    return block_scale;
 }
 
 static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -1507,6 +1507,14 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
 
         rknn_matmul_ctx sync_ctx = g_domain_manager.get_allocator_context(alloc.iommu_domain_id);
         RKNN_CHECK(rknn_mem_sync(sync_ctx, alloc.mem, RKNN_MEMORY_SYNC_TO_DEVICE), "sync B TO_DEVICE");
+
+        // TST.2: also keep the raw GGUF bytes in tensor->data so cross-backend
+        // copies (ggml_backend_tensor_copy via get_tensor) and any other
+        // external read-back returns the original format instead of the
+        // NPU-packed bytes that live in alloc.mem. tensor->data already lives
+        // inside the mmap'd virtual_base, so this is a one-time extra memcpy
+        // at model load with no additional allocation.
+        memcpy((uint8_t*)tensor->data + offset, data, size);
     } else {
         memcpy((uint8_t*)tensor->data + offset, data, size);
     }
@@ -1514,15 +1522,13 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
 
 static void ggml_backend_rknpu_buffer_get_tensor(ggml_backend_buffer_t buffer, const struct ggml_tensor * tensor, void * data, size_t offset, size_t size) {
     auto * ctx = (ggml_backend_rknpu_buffer_context*)buffer->context;
-    size_t tensor_offset_in_virtual = (uintptr_t)tensor->data - (uintptr_t)ctx->virtual_base;
+    UNUSED(ctx);
 
-    std::lock_guard<std::mutex> lock(ctx->mutex);
-    auto it = ctx->tensor_allocs.find(tensor_offset_in_virtual);
-    if (it != ctx->tensor_allocs.end()) {
-        memcpy(data, (uint8_t*)it->second.mem->virt_addr + offset, size);
-    } else {
-        memcpy(data, (uint8_t*)tensor->data + offset, size);
-    }
+    // TST.2: tensor->data is now the source of truth for the original GGUF
+    // bytes (set_tensor's pipeline path memcpy's there too). Reading from
+    // alloc.mem would give NPU-packed bytes, which CPU consumers cannot
+    // interpret as Q8_0 / F16 / etc — see TST.1 findings.
+    memcpy(data, (uint8_t*)tensor->data + offset, size);
 }
 
 static void ggml_backend_rknpu_buffer_clear(ggml_backend_buffer_t buffer, uint8_t value) {

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -41,6 +41,17 @@ static bool rknpu_batched_diag_enabled() {
     return enabled;
 }
 
+// F8.3 gate: when RKNPU_BATCHED_MM_ENABLE=1, supports_op accepts mul_mat ops
+// with src1->ne[2] > 1 (broadcast n_head_q over a rank-2 src0). Default off
+// keeps the F8.1 baseline shape coverage intact for safe rollout.
+static bool rknpu_batched_mm_enabled() {
+    static const bool enabled = []() {
+        const char* v = std::getenv("RKNPU_BATCHED_MM_ENABLE");
+        return v != nullptr && v[0] != '\0' && v[0] != '0';
+    }();
+    return enabled;
+}
+
 static void rknpu_log_batched_shape_once(
         const struct ggml_tensor * src0,
         const struct ggml_tensor * src1,
@@ -313,6 +324,16 @@ struct ggml_backend_rknpu_buffer_context {
         rknn_tensor_mem* mem = nullptr;
         size_t size = 0;
         int32_t iommu_domain_id = 0;
+        // F8.3: init_tensor creates an alloc for any pipelined tensor; only
+        // set_tensor's pipeline path actually populates the DMA buffer.
+        // graph_compute uses pre_quantized to gate the static fast path.
+        bool pre_quantized = false;
+        // F8.3: count of set_tensor invocations on this alloc. Real weights
+        // see exactly one (load-time). Scheduler-managed copy tensors (e.g.
+        // F16 KV cache views the sched dups into the RKNPU buffer for batched
+        // attention) see one per inference step. We pre-quantize on the first
+        // call and demote to memcpy on any subsequent call.
+        int set_count = 0;
     };
     std::unordered_map<size_t, TensorAllocation> tensor_allocs;
 
@@ -638,40 +659,52 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
         std::shared_ptr<rknn_tensor_mem> mem_A_shared;
         std::vector<std::shared_ptr<rknn_tensor_mem>> mem_C_segments(num_active_segments);
 
-        // F8.2: split static (pre-quantized weight) vs dynamic (per-call src0)
-        // path. Today's supports_op only routes the static case here; the
-        // dynamic branch becomes reachable once F8.3 relaxes the rank>2 guard.
-        const bool src0_in_rknpu = is_rknpu_buffer(src0);
-
-        // Acquiring the B-matrix buffer (static path only)
+        // F8.2/F8.3 path discriminator: src0 takes the static (FD-mapped, pre-
+        // quantized) path only when an RKNPU alloc record exists for it.
+        // Otherwise (CPU-resident src0, or RKNPU-resident but not pre-quantized
+        // — e.g. K/V copied in by the scheduler for batched attention), we use
+        // the dynamic path that quantizes/packs src0 inline.
         ggml_backend_rknpu_buffer_context* src0_buf_ctx = nullptr;
         size_t tensor_offset_in_virtual = 0;
+        bool src0_is_pre_quantized = false;
         int32_t b_domain_id = 0;
         int tensor_fd = -1;
         void* tensor_virt_addr = nullptr;
-        if (src0_in_rknpu) {
-            ggml_backend_buffer_t src0_buffer = src0->buffer;
-            src0_buf_ctx = (ggml_backend_rknpu_buffer_context*)src0_buffer->context;
+        if (is_rknpu_buffer(src0)) {
+            src0_buf_ctx = (ggml_backend_rknpu_buffer_context*)src0->buffer->context;
             tensor_offset_in_virtual = (uintptr_t)src0->data - (uintptr_t)src0_buf_ctx->virtual_base;
 
             std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
             auto it = src0_buf_ctx->tensor_allocs.find(tensor_offset_in_virtual);
-            GGML_ASSERT(it != src0_buf_ctx->tensor_allocs.end() && "B-matrix RKNN buffer not found");
-
-            tensor_fd = it->second.mem->fd;
-            tensor_virt_addr = it->second.mem->virt_addr;
-            b_domain_id = it->second.iommu_domain_id;
+            if (it != src0_buf_ctx->tensor_allocs.end() && it->second.pre_quantized) {
+                src0_is_pre_quantized = true;
+                tensor_fd = it->second.mem->fd;
+                tensor_virt_addr = it->second.mem->virt_addr;
+                b_domain_id = it->second.iommu_domain_id;
+            }
         }
+        const bool use_static_path = src0_is_pre_quantized;
 
-        // Cleaning the C-matrix buffer. dst lives in the RKNPU buffer when src0
-        // does (static); in the dynamic path dst is a normal CPU tensor.
-        float* dst_data = src0_in_rknpu ? (float*)get_tensor_real_ptr(dst) : (float*)dst->data;
-        memset(dst_data, 0, (size_t)M * N * sizeof(float));
+        // F8.3: dst (and src1) may carry a head dim ne[2] that broadcasts a
+        // single rank-2 src0 across n_heads sub-matmuls. n_heads=1 collapses
+        // to the original single-matmul path.
+        const int n_heads = (int)dst->ne[2];
+        GGML_ASSERT(n_heads >= 1 && "dst->ne[2] must be >= 1");
+        const size_t src1_head_stride = (n_heads > 1) ? (src1->nb[2] / sizeof(float)) : 0;
+        const size_t dst_head_stride  = (n_heads > 1) ? (dst->nb[2]  / sizeof(float)) : 0;
+
+        // Cleaning the C-matrix buffer (per head, since dst may be non-contig
+        // along ne[2] for permuted attention outputs).
+        float* dst_data = (float*)get_tensor_real_ptr(dst);
+        for (int h = 0; h < n_heads; ++h) {
+            float* dst_h = dst_data + (size_t)h * dst_head_stride;
+            memset(dst_h, 0, (size_t)M * N * sizeof(float));
+        }
 
         // Acquiring the Hadamard vector
         std::vector<float> s_vec;
         if (is_hadamard) {
-            if (src0_in_rknpu) {
+            if (use_static_path) {
                 std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
                 auto it = src0_buf_ctx->hadamard_s_vectors.find(src0);
                 GGML_ASSERT(it != src0_buf_ctx->hadamard_s_vectors.end() && "Hadamard 's' vector not found");
@@ -692,7 +725,7 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
         // the buffer ctx; dynamic path fills it inline below as we quantize
         // each (k_seg, n_seg) block.
         std::vector<float> scales_B_grid;
-        if (src0_in_rknpu) {
+        if (use_static_path) {
             if (pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT8 || pipeline->npu_type_b == rknpu2_configuration::NPU_TYPE_INT4) {
                 std::lock_guard<std::mutex> lock(src0_buf_ctx->mutex);
                 auto it = src0_buf_ctx->quantized_tensor_scales.find(src0);
@@ -721,7 +754,7 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                 for (size_t idx = 0; idx < num_active_segments; ++idx) {
                     if (active_n_segments[idx].offset_n != n_seg.offset_n) continue;
 
-                    if (src0_in_rknpu) {
+                    if (use_static_path) {
                         // Static path: B was pre-quantized + packed at set_tensor
                         // time and lives at a known offset inside the FD-mapped
                         // tensor blob; bind once via create_mem_from_fd.
@@ -794,180 +827,211 @@ static enum ggml_status ggml_backend_rknpu_graph_compute(ggml_backend_t backend,
                     break;
                 }
 
-                if (src0_in_rknpu && n_seg.size_n > 0) {
+                if (use_static_path && n_seg.size_n > 0) {
                     current_offset_in_tensor += type_size_packed > 0 ? (size_t)n_seg.size_n * K_seg_op * type_size_packed : (size_t)n_seg.size_n * K_seg_op / 2;
                 }
             }
 
-            // ===========================================
-            // ========== 2. Preparing A-matrix ==========
-            // ===========================================
-            std::vector<float> scales_A(M, 1.0f);
-            {
-                auto cache_key = std::make_tuple(M_op, K_seg_op, (int)pipeline->npu_type_a, b_domain_id);
-                auto& matmul_ctx_0 = matmul_ctxs[0];
-
-                // Getting A-buffer from cache
-                mem_A_shared = get_tensor_buffer(backend_ctx, matmul_ctx_0->ctx, matmul_ctx_0->io_attr.A.size, cache_key, backend_ctx->a_buffer_cache);
-                if (!mem_A_shared) return GGML_STATUS_FAILED;
-
-                const float* x = (const float*)get_tensor_real_ptr(src1);
-                const int row_stride = (int)(src1->nb[1] / sizeof(float));
-                void* dst_base = mem_A_shared->virt_addr;
-
-                #pragma omp parallel for
-                for (int m = 0; m < M; ++m) {
-                    const float* src_row = x + (size_t)m * row_stride;
-                    std::vector<float> ready_row(K_seg_op);
-
-                    // Applying Hadamard Transform
-                    if (is_hadamard) {
-                        std::vector<float> signed_row(K);
-                        std::vector<float> full_hadamard_row(K_op);
-                        for(int k=0; k<K; ++k) signed_row[k] = src_row[k] * s_vec[k];
-                        rknpu2_calibration::hadamard_transform(full_hadamard_row.data(), signed_row.data(), K, K_op);
-
-                        memcpy(ready_row.data(), full_hadamard_row.data() + k_seg.offset_k, K_seg_op * sizeof(float));
-                    } else {
-                        memcpy(ready_row.data(), src_row + k_seg.offset_k, K_seg_op * sizeof(float));
-                    }
-
-                    // Handling types and quantizations
-                    if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_FP16) {
-                        uint16_t* dst_ptr = (uint16_t*)dst_base;
-                        uint16_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
-                        rknpu2_quantization::convert_fp32_to_fp16(ready_row.data(), dst_row, K_seg_op);
-                    }
-                    else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT8) {
-                        float amax_m = 0.0f;
-                        for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
-                        scales_A[m] = amax_m / 127.0f;
-
-                        int8_t* dst_ptr = (int8_t*)dst_base;
-                        int8_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
-                        rknpu2_quantization::quantize_fp32_to_int8(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
-                    }
-                    else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT4) {
-                        float amax_m = 0.0f;
-                        for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
-                        scales_A[m] = amax_m / 7.0f;
-
-                        uint8_t* dst_ptr = (uint8_t*)dst_base;
-                        uint8_t* dst_row = dst_ptr + (size_t)m * (K_seg_op / 2);
-                        rknpu2_quantization::quantize_fp32_to_int4_packed(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
-                    }
-                }
-
-                // Assigning A-matrix to all contexts for the parallel execution
-                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                    RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctxs[idx]->ctx, mem_A_shared.get(), &matmul_ctxs[idx]->io_attr.A), "set_io_mem A for core");
-                }
-
-                RKNN_CHECK(rknn_mem_sync(matmul_ctxs[0]->ctx, mem_A_shared.get(), RKNN_MEMORY_SYNC_TO_DEVICE), "sync A TO_DEVICE");
-            }
-
-            // ===========================================
-            // ========== 3. Preparing C-matrix ==========
-            // ===========================================
-            {
-                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                    auto& matmul_ctx = matmul_ctxs[idx];
-                    auto cache_key = std::make_tuple(M_op, active_n_segments[idx].size_n, active_n_segments[idx].core_id, (int)pipeline->npu_type_c, b_domain_id);
-
-                    // Getting C-buffer from cache
-                    mem_C_segments[idx] = get_tensor_buffer(backend_ctx, matmul_ctx->ctx, matmul_ctx->io_attr.C.size, cache_key, backend_ctx->c_buffer_cache);
-                    if (!mem_C_segments[idx]) return GGML_STATUS_FAILED;
-
-                    // Assigning C-matrix to current context for the parallel execution
-                    RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctx->ctx, mem_C_segments[idx].get(), &matmul_ctx->io_attr.C), "set_io_mem C");
+            // F8.3 head loop: src1/dst can carry a head dim (ne[2] = n_heads)
+            // that broadcasts the rank-2 src0/B across n_heads sub-matmuls.
+            // For static (n_heads=1) this collapses to the original code.
+            // B preparation above already happened once per k_seg and is
+            // amortized across all heads.
+            if (rknpu_batched_diag_enabled() && n_heads > 1 && k_idx == 0) {
+                static std::mutex m;
+                static std::unordered_set<std::string> seen;
+                char key[512];
+                std::snprintf(key, sizeof(key),
+                    "ROUTED static=%d M=%d K=%d N=%d n_heads=%d src0=%s/%s/op=%d/view_src=%p/flags=0x%x src1=%s dst=%s op=%s",
+                    use_static_path ? 1 : 0, M, K, N, n_heads,
+                    ggml_type_name(src0->type),
+                    src0->name[0] ? src0->name : "?",
+                    (int)src0->op,
+                    (void*)src0->view_src,
+                    (unsigned)src0->flags,
+                    ggml_type_name(src1->type),
+                    ggml_type_name(dst->type),
+                    node->name[0] ? node->name : "?");
+                std::lock_guard<std::mutex> lock(m);
+                if (seen.insert(key).second) {
+                    std::fprintf(stderr, "RKNPU_BATCHED_ROUTED %s\n", key);
                 }
             }
+            const float* x_base = (const float*)get_tensor_real_ptr(src1);
 
-            // ==========================================
-            // ========== 4. Running operation ==========
-            // ==========================================
-            {
-                #pragma omp parallel for num_threads(num_active_segments)
-                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                    int ret = rknn_matmul_run(matmul_ctxs[idx]->ctx);
-                    if (ret != RKNN_SUCC) {
-                        // Handle error
-                    }
-                }
-            }
+            for (int h = 0; h < n_heads; ++h) {
+                const float* x = x_base + (size_t)h * src1_head_stride;
+                float* dst_data_h = dst_data + (size_t)h * dst_head_stride;
 
-            // ===========================================
-            // ========== 5. Collecting results ==========
-            // ===========================================
-            {
-                for (size_t idx = 0; idx < num_active_segments; idx++) {
-                    RKNN_CHECK(rknn_mem_sync(matmul_ctxs[idx]->ctx, mem_C_segments[idx].get(), RKNN_MEMORY_SYNC_FROM_DEVICE), "sync C FROM_DEVICE");
-                }
+                // ===========================================
+                // ========== 2. Preparing A-matrix ==========
+                // ===========================================
+                std::vector<float> scales_A(M, 1.0f);
+                {
+                    auto cache_key = std::make_tuple(M_op, K_seg_op, (int)pipeline->npu_type_a, b_domain_id);
+                    auto& matmul_ctx_0 = matmul_ctxs[0];
 
-                const float hadamard_divisor = pipeline->use_hadamard ? (float)K_op : 1.0f;
+                    // Getting A-buffer from cache
+                    mem_A_shared = get_tensor_buffer(backend_ctx, matmul_ctx_0->ctx, matmul_ctx_0->io_attr.A.size, cache_key, backend_ctx->a_buffer_cache);
+                    if (!mem_A_shared) return GGML_STATUS_FAILED;
 
-                #pragma omp parallel for
-                for (int m = 0; m < M; m++) {
-                    // Handling types and quantizations
-                    switch (pipeline->npu_type_c) {
-                        case rknpu2_configuration::NPU_TYPE_FP32: {
-                            for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
+                    const int row_stride = (int)(src1->nb[1] / sizeof(float));
+                    void* dst_base = mem_A_shared->virt_addr;
 
-                                int N_offset = active_n_segments[idx].offset_n;
-                                int N_segment = active_n_segments[idx].size_n;
-                                float* src_segment_base = (float*)mem_C_segments[idx]->virt_addr;
-                                float* dst_ptr = dst_data + (size_t)m * N + N_offset;
-                                float* src_ptr = src_segment_base + (size_t)m * N_segment;
+                    #pragma omp parallel for
+                    for (int m = 0; m < M; ++m) {
+                        const float* src_row = x + (size_t)m * row_stride;
+                        std::vector<float> ready_row(K_seg_op);
 
-                                for(int n=0; n<N_segment; ++n) {
-                                    dst_ptr[n] += src_ptr[n] * dequant_scale;
-                                }
-                            }
-                            break;
+                        // Applying Hadamard Transform
+                        if (is_hadamard) {
+                            std::vector<float> signed_row(K);
+                            std::vector<float> full_hadamard_row(K_op);
+                            for(int k=0; k<K; ++k) signed_row[k] = src_row[k] * s_vec[k];
+                            rknpu2_calibration::hadamard_transform(full_hadamard_row.data(), signed_row.data(), K, K_op);
+
+                            memcpy(ready_row.data(), full_hadamard_row.data() + k_seg.offset_k, K_seg_op * sizeof(float));
+                        } else {
+                            memcpy(ready_row.data(), src_row + k_seg.offset_k, K_seg_op * sizeof(float));
                         }
 
-                        case rknpu2_configuration::NPU_TYPE_INT32: {
-                            for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
-
-                                int N_offset = active_n_segments[idx].offset_n;
-                                int N_segment = active_n_segments[idx].size_n;
-                                float* dst_ptr = dst_data + (size_t)m * N + N_offset;
-                                int32_t* src_ptr = (int32_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
-
-                                for(int n=0; n<N_segment; ++n) {
-                                    dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
-                                }
-                            }
-                            break;
+                        // Handling types and quantizations
+                        if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_FP16) {
+                            uint16_t* dst_ptr = (uint16_t*)dst_base;
+                            uint16_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
+                            rknpu2_quantization::convert_fp32_to_fp16(ready_row.data(), dst_row, K_seg_op);
                         }
+                        else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT8) {
+                            float amax_m = 0.0f;
+                            for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
+                            scales_A[m] = amax_m / 127.0f;
 
-                        case rknpu2_configuration::NPU_TYPE_INT16: {
-                            for (size_t idx = 0; idx < num_active_segments; idx++) {
-                                float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
-                                float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
-
-                                int N_offset = active_n_segments[idx].offset_n;
-                                int N_segment = active_n_segments[idx].size_n;
-                                float* dst_ptr = dst_data + (size_t)m * N + N_offset;
-                                int16_t* src_ptr = (int16_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
-
-                                for(int n=0; n<N_segment; ++n) {
-                                    dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
-                                }
-                            }
-                            break;
+                            int8_t* dst_ptr = (int8_t*)dst_base;
+                            int8_t* dst_row = dst_ptr + (size_t)m * K_seg_op;
+                            rknpu2_quantization::quantize_fp32_to_int8(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
                         }
+                        else if (pipeline->npu_type_a == rknpu2_configuration::NPU_TYPE_INT4) {
+                            float amax_m = 0.0f;
+                            for (int k = 0; k < K_seg_op; ++k) amax_m = std::max(amax_m, std::abs(ready_row[k]));
+                            scales_A[m] = amax_m / 7.0f;
 
-                        default:
-                            // This should not be reached if config is correct
-                            break;
+                            uint8_t* dst_ptr = (uint8_t*)dst_base;
+                            uint8_t* dst_row = dst_ptr + (size_t)m * (K_seg_op / 2);
+                            rknpu2_quantization::quantize_fp32_to_int4_packed(ready_row.data(), dst_row, K_seg_op, scales_A[m]);
+                        }
+                    }
+
+                    // Assigning A-matrix to all contexts for the parallel execution
+                    for (size_t idx = 0; idx < num_active_segments; idx++) {
+                        RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctxs[idx]->ctx, mem_A_shared.get(), &matmul_ctxs[idx]->io_attr.A), "set_io_mem A for core");
+                    }
+
+                    RKNN_CHECK(rknn_mem_sync(matmul_ctxs[0]->ctx, mem_A_shared.get(), RKNN_MEMORY_SYNC_TO_DEVICE), "sync A TO_DEVICE");
+                }
+
+                // ===========================================
+                // ========== 3. Preparing C-matrix ==========
+                // ===========================================
+                {
+                    for (size_t idx = 0; idx < num_active_segments; idx++) {
+                        auto& matmul_ctx = matmul_ctxs[idx];
+                        auto cache_key = std::make_tuple(M_op, active_n_segments[idx].size_n, active_n_segments[idx].core_id, (int)pipeline->npu_type_c, b_domain_id);
+
+                        // Getting C-buffer from cache
+                        mem_C_segments[idx] = get_tensor_buffer(backend_ctx, matmul_ctx->ctx, matmul_ctx->io_attr.C.size, cache_key, backend_ctx->c_buffer_cache);
+                        if (!mem_C_segments[idx]) return GGML_STATUS_FAILED;
+
+                        // Assigning C-matrix to current context for the parallel execution
+                        RKNN_CHECK(rknn_matmul_set_io_mem(matmul_ctx->ctx, mem_C_segments[idx].get(), &matmul_ctx->io_attr.C), "set_io_mem C");
                     }
                 }
-            }
+
+                // ==========================================
+                // ========== 4. Running operation ==========
+                // ==========================================
+                {
+                    #pragma omp parallel for num_threads(num_active_segments)
+                    for (size_t idx = 0; idx < num_active_segments; idx++) {
+                        int ret = rknn_matmul_run(matmul_ctxs[idx]->ctx);
+                        if (ret != RKNN_SUCC) {
+                            // Handle error
+                        }
+                    }
+                }
+
+                // ===========================================
+                // ========== 5. Collecting results ==========
+                // ===========================================
+                {
+                    for (size_t idx = 0; idx < num_active_segments; idx++) {
+                        RKNN_CHECK(rknn_mem_sync(matmul_ctxs[idx]->ctx, mem_C_segments[idx].get(), RKNN_MEMORY_SYNC_FROM_DEVICE), "sync C FROM_DEVICE");
+                    }
+
+                    const float hadamard_divisor = pipeline->use_hadamard ? (float)K_op : 1.0f;
+
+                    #pragma omp parallel for
+                    for (int m = 0; m < M; m++) {
+                        // Handling types and quantizations
+                        switch (pipeline->npu_type_c) {
+                            case rknpu2_configuration::NPU_TYPE_FP32: {
+                                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
+
+                                    int N_offset = active_n_segments[idx].offset_n;
+                                    int N_segment = active_n_segments[idx].size_n;
+                                    float* src_segment_base = (float*)mem_C_segments[idx]->virt_addr;
+                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                    float* src_ptr = src_segment_base + (size_t)m * N_segment;
+
+                                    for(int n=0; n<N_segment; ++n) {
+                                        dst_ptr[n] += src_ptr[n] * dequant_scale;
+                                    }
+                                }
+                                break;
+                            }
+
+                            case rknpu2_configuration::NPU_TYPE_INT32: {
+                                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
+
+                                    int N_offset = active_n_segments[idx].offset_n;
+                                    int N_segment = active_n_segments[idx].size_n;
+                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                    int32_t* src_ptr = (int32_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
+
+                                    for(int n=0; n<N_segment; ++n) {
+                                        dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
+                                    }
+                                }
+                                break;
+                            }
+
+                            case rknpu2_configuration::NPU_TYPE_INT16: {
+                                for (size_t idx = 0; idx < num_active_segments; idx++) {
+                                    float scale_B = scales_B_grid.empty() ? 1.0f : scales_B_grid[k_idx * num_active_segments + idx];
+                                    float dequant_scale = (scales_A[m] * scale_B) / hadamard_divisor;
+
+                                    int N_offset = active_n_segments[idx].offset_n;
+                                    int N_segment = active_n_segments[idx].size_n;
+                                    float* dst_ptr = dst_data_h + (size_t)m * N + N_offset;
+                                    int16_t* src_ptr = (int16_t*)mem_C_segments[idx]->virt_addr + (size_t)m * N_segment;
+
+                                    for(int n=0; n<N_segment; ++n) {
+                                        dst_ptr[n] += (float)src_ptr[n] * dequant_scale;
+                                    }
+                                }
+                                break;
+                            }
+
+                            default:
+                                // This should not be reached if config is correct
+                                break;
+                        }
+                    }
+                }
+            } // end head loop
         }
     }
 
@@ -1046,7 +1110,9 @@ static enum ggml_status ggml_backend_rknpu_buffer_init_tensor(ggml_backend_buffe
     const auto& config = rknpu2_configuration::Rknpu2ConfigManager::get_instance().get_current_config();
     const auto* pipeline = config.resolve_op_support(tensor);
 
-    // Initialize tensor only if it is supported by the pipeline
+    // Initialize tensor only if it is supported by the pipeline. The DMA
+    // buffer is owned by the alloc; whether it actually holds pre-quantized
+    // bytes is decided in set_tensor (first call only).
     if (pipeline) {
         size_t offset = (uintptr_t)tensor->data - (uintptr_t)ctx->virtual_base;
         size_t size = get_tensor_packed_size(tensor);
@@ -1328,7 +1394,31 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
 
     size_t tensor_offset_in_virtual = (uintptr_t)tensor->data - (uintptr_t)ctx->virtual_base;
 
+    // F8.3: pre-quantize only the FIRST set_tensor call against an alloc.
+    // Real weights see exactly one such call at model load. Scheduler-managed
+    // copy tensors (the F16 KV-cache slices ggml_backend_sched dups into the
+    // RKNPU buffer for batched attention) see a fresh set_tensor every step —
+    // demote those to memcpy so graph_compute reads fresh values via the
+    // dynamic path. INPUT/OUTPUT flags are unreliable (the sched only sets
+    // them when n_copies > 1; default n_copies is 1), so we count the calls.
+    bool is_first_call = false;
+    bool is_repeat_call = false;
     if (pipeline) {
+        size_t required_size = get_tensor_packed_size(tensor);
+        ctx->get_tensor_allocation(tensor_offset_in_virtual, required_size);
+        std::lock_guard<std::mutex> lock(ctx->mutex);
+        auto it = ctx->tensor_allocs.find(tensor_offset_in_virtual);
+        GGML_ASSERT(it != ctx->tensor_allocs.end());
+        const int prev_count = it->second.set_count++;
+        if (prev_count == 0) {
+            is_first_call = true;
+        } else {
+            is_repeat_call = true;
+            it->second.pre_quantized = false;
+        }
+    }
+
+    if (pipeline && is_first_call) {
         const int K = (int)tensor->ne[0];
         const int N = (int)tensor->ne[1];
         const int K_op = pipeline->use_hadamard ? rknpu2_calibration::next_power_of_two(K) : K;
@@ -1405,6 +1495,14 @@ static void ggml_backend_rknpu_buffer_set_tensor(ggml_backend_buffer_t buffer, s
         {
             std::lock_guard<std::mutex> lock(ctx->mutex);
             ctx->quantized_tensor_scales[tensor] = tensor_block_scales;
+            // F8.3: mark this alloc as actually pre-quantized so graph_compute
+            // can distinguish it from init_tensor-allocated runtime tensors
+            // (e.g. F16 KV cache slabs) that share the alloc map but have
+            // never had quantized bytes written to their DMA buffer.
+            auto it = ctx->tensor_allocs.find(tensor_offset_in_virtual);
+            if (it != ctx->tensor_allocs.end()) {
+                it->second.pre_quantized = true;
+            }
         }
 
         rknn_matmul_ctx sync_ctx = g_domain_manager.get_allocator_context(alloc.iommu_domain_id);
@@ -1536,20 +1634,34 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
             return true;
 
         case GGML_OP_MUL_MAT: {
-            const struct ggml_tensor * src0 = op->src[0]; // Weights
+            const struct ggml_tensor * src0 = op->src[0]; // Weights / runtime B
             const struct ggml_tensor * src1 = op->src[1]; // Activations
 
-            // The current RKNPU matmul path only handles plain 2D matrices.
-            // Batched / higher-rank ggml_mul_mat tensors require semantics that
-            // depend on ne[2]/ne[3], but the implementation below only uses K/N/M
-            // from ne[0]/ne[1]. Reject them so they fall back to CPU.
+            // src0 is always rank-2 here. src1 / op may be rank-3 (broadcast
+            // over n_head_q) when F8.3 is enabled. ne[3] must always be 1.
+            const bool batched_ok = rknpu_batched_mm_enabled();
+            const bool batched_shape =
+                (src1->ne[2] > 1) || (op->ne[2] > 1);
+
             if (src0->ne[2] != 1 || src0->ne[3] != 1 ||
-                src1->ne[2] != 1 || src1->ne[3] != 1 ||
-                op->ne[2]   != 1 || op->ne[3]   != 1) {
+                src1->ne[3] != 1 || op->ne[3] != 1) {
                 if (rknpu_batched_diag_enabled()) {
                     rknpu_log_batched_shape_once(src0, src1, op);
                 }
                 return false;
+            }
+
+            if (batched_shape) {
+                if (!batched_ok) {
+                    if (rknpu_batched_diag_enabled()) {
+                        rknpu_log_batched_shape_once(src0, src1, op);
+                    }
+                    return false;
+                }
+                // dst's head dim must match src1's; we slice both by nb[2].
+                if (op->ne[2] != src1->ne[2]) {
+                    return false;
+                }
             }
 
             // Searching for available hardware pipeline for this tensor
@@ -1584,9 +1696,20 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                  return false;
             }
 
-            // Checking contiguous memory
-            if (!ggml_is_contiguous(src0) || !ggml_is_contiguous(src1)) {
+            // src0 must be contiguous (we read it row-major in dequantize_row).
+            // For batched src1 we only require contiguous rows so permuted
+            // attention Q (post permute(0,2,1,3)) is acceptable.
+            if (!ggml_is_contiguous(src0)) {
                 return false;
+            }
+            if (batched_shape) {
+                if (!ggml_is_contiguous_rows(src1)) {
+                    return false;
+                }
+            } else {
+                if (!ggml_is_contiguous(src1)) {
+                    return false;
+                }
             }
 
             return true;

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -25,8 +25,51 @@
 #include <limits>
 #include <sys/mman.h>
 #include <sstream>
+#include <cstdio>
+#include <unordered_set>
 
 #define UNUSED(x) (void)(x)
+
+// F8.0 diagnostic: when RKNPU_BATCHED_MM_DIAGNOSTIC=1, log shapes that the
+// supports_op rank>2 guard rejects today. Used to scope the F8 work without
+// changing behavior. Each unique shape is logged once to stderr.
+static bool rknpu_batched_diag_enabled() {
+    static const bool enabled = []() {
+        const char* v = std::getenv("RKNPU_BATCHED_MM_DIAGNOSTIC");
+        return v != nullptr && v[0] != '\0' && v[0] != '0';
+    }();
+    return enabled;
+}
+
+static void rknpu_log_batched_shape_once(
+        const struct ggml_tensor * src0,
+        const struct ggml_tensor * src1,
+        const struct ggml_tensor * op) {
+    static std::mutex m;
+    static std::unordered_set<std::string> seen;
+
+    char key[768];
+    std::snprintf(key, sizeof(key),
+        "name=%s op_name=%s "
+        "src0=%s[%lld,%lld,%lld,%lld]@nb[%zu,%zu,%zu,%zu] "
+        "src1=%s[%lld,%lld,%lld,%lld]@nb[%zu,%zu,%zu,%zu] "
+        "dst=%s[%lld,%lld,%lld,%lld]",
+        op->name[0]   ? op->name   : "?",
+        src0->name[0] ? src0->name : "?",
+        ggml_type_name(src0->type),
+        (long long)src0->ne[0], (long long)src0->ne[1], (long long)src0->ne[2], (long long)src0->ne[3],
+        (size_t)src0->nb[0], (size_t)src0->nb[1], (size_t)src0->nb[2], (size_t)src0->nb[3],
+        ggml_type_name(src1->type),
+        (long long)src1->ne[0], (long long)src1->ne[1], (long long)src1->ne[2], (long long)src1->ne[3],
+        (size_t)src1->nb[0], (size_t)src1->nb[1], (size_t)src1->nb[2], (size_t)src1->nb[3],
+        ggml_type_name(op->type),
+        (long long)op->ne[0], (long long)op->ne[1], (long long)op->ne[2], (long long)op->ne[3]);
+
+    std::lock_guard<std::mutex> lock(m);
+    if (seen.insert(key).second) {
+        std::fprintf(stderr, "RKNPU_BATCHED_DIAG %s\n", key);
+    }
+}
 
 // --- IOMMU Domain Manager ---
 
@@ -1279,6 +1322,19 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
         case GGML_OP_MUL_MAT: {
             const struct ggml_tensor * src0 = op->src[0]; // Weights
             const struct ggml_tensor * src1 = op->src[1]; // Activations
+
+            // The current RKNPU matmul path only handles plain 2D matrices.
+            // Batched / higher-rank ggml_mul_mat tensors require semantics that
+            // depend on ne[2]/ne[3], but the implementation below only uses K/N/M
+            // from ne[0]/ne[1]. Reject them so they fall back to CPU.
+            if (src0->ne[2] != 1 || src0->ne[3] != 1 ||
+                src1->ne[2] != 1 || src1->ne[3] != 1 ||
+                op->ne[2]   != 1 || op->ne[3]   != 1) {
+                if (rknpu_batched_diag_enabled()) {
+                    rknpu_log_batched_shape_once(src0, src1, op);
+                }
+                return false;
+            }
 
             // Searching for available hardware pipeline for this tensor
             const auto* pipeline = config.resolve_op_support(src0);

--- a/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
+++ b/ggml/src/ggml-rknpu2/ggml-rknpu2.cpp
@@ -1893,22 +1893,33 @@ static bool ggml_backend_rknpu_device_supports_op(ggml_backend_dev_t dev, const 
                     return false;
                 }
 
-                // F8.6b stability cap: F8.6b's flatten asks the NPU for one
-                // matmul of M_total = M * n_heads rows. CBUF can't hold A
-                // larger than max_m rows for the given K, and the librknnrt
-                // 2.3.2 driver crashes silently past that. Reject the op so
-                // it falls back to CPU; F8.6c will replace this with M-tiling.
-                const auto* pipe_for_cap = config.resolve_op_support(src0);
-                if (pipe_for_cap) {
-                    const int K_seg_worst = (int)src0->ne[0];
-                    const int max_m = rknpu_max_m_for_cbuf(pipe_for_cap, K_seg_worst);
-                    const int64_t M_total = src1->ne[1] * src1->ne[2];
-                    if (M_total > max_m) {
-                        if (rknpu_batched_diag_enabled()) {
-                            rknpu_log_batched_shape_once(src0, src1, op);
+                // F8.6b CBUF cap experiment outcome: with the F8.5.CLEAN
+                // teardown fix, the original "crashing" shape
+                // (M_total=2048, K=512, FP16) runs cleanly on librknnrt
+                // 2.3.2. The crash was the destructor bug, NOT a hardware
+                // capacity wall. allbilly/npu's CBUF formula applies to
+                // their pure-C driver, not to librknnrt.
+                // Cap is now OPT-IN via RKNPU_BATCHED_MM_ENABLE_CBUF_CAP=1
+                // to keep the diagnostic available, but default OFF — let
+                // librknnrt decide. F8.6e (M-tile) becomes a perf knob
+                // instead of a stability requirement.
+                static const bool enable_cbuf_cap = []() {
+                    const char* v = std::getenv("RKNPU_BATCHED_MM_ENABLE_CBUF_CAP");
+                    return v != nullptr && v[0] != '\0' && v[0] != '0';
+                }();
+                if (enable_cbuf_cap) {
+                    const auto* pipe_for_cap = config.resolve_op_support(src0);
+                    if (pipe_for_cap) {
+                        const int K_seg_worst = (int)src0->ne[0];
+                        const int max_m = rknpu_max_m_for_cbuf(pipe_for_cap, K_seg_worst);
+                        const int64_t M_total = src1->ne[1] * src1->ne[2];
+                        if (M_total > max_m) {
+                            if (rknpu_batched_diag_enabled()) {
+                                rknpu_log_batched_shape_once(src0, src1, op);
+                            }
+                            stats.rejected_cbuf.fetch_add(1, std::memory_order_relaxed);
+                            return false;
                         }
-                        stats.rejected_cbuf.fetch_add(1, std::memory_order_relaxed);
-                        return false;
                     }
                 }
             }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7991,6 +7991,39 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // F8.3 / TST.1 — sanity coverage for the production W8A8 path (Q8_0 weights).
+    // n_align=32 for W8A8, k_align=32; pick shapes that satisfy both. Without
+    // these, no Q8_0 mul_mat is exercised by test-backend-ops on RKNPU.
+    for (int m_q : {32, 256, 512}) {
+        for (int n_q : {1, 16, 64}) {
+            for (int k_q : {256, 512}) {
+                test_cases.emplace_back(new test_mul_mat(
+                    GGML_TYPE_Q8_0, GGML_TYPE_F32,
+                    /*m=*/m_q, /*n=*/n_q, /*k=*/k_q,
+                    /*bs=*/{1, 1}, /*nr=*/{1, 1}));
+            }
+        }
+    }
+
+    // F8.3 / TST.1 — synthetic GQA-style batched mul_mat coverage.
+    // src0 = F16 [head_dim, kv_len, 1, 1]   (rank-2 K cache view)
+    // src1 = F32 [head_dim, q_len, n_head_q, 1]
+    // dst  = F32 [kv_len,   q_len, n_head_q, 1]
+    // Maps to test_mul_mat(F16, F32, m=kv_len, n=q_len, k=head_dim, bs={1,1}, nr={n_head_q,1}).
+    // Matches the shapes captured by F8.0 diagnostic on gemma-4-E2B (n_head_q=8).
+    for (int n_heads : {1, 8}) {
+        for (int t_q : {1, 16, 64, 256}) {
+            for (auto kn : std::vector<std::pair<int,int>>{ {256,256}, {256,512}, {512,256}, {512,512} }) {
+                int k = kn.first;
+                int n = kn.second;
+                test_cases.emplace_back(new test_mul_mat(
+                    GGML_TYPE_F16, GGML_TYPE_F32,
+                    /*m=*/n, /*n=*/t_q, /*k=*/k,
+                    /*bs=*/{1, 1}, /*nr=*/{n_heads, 1}));
+            }
+        }
+    }
+
 #if 0
     {
         // Test paths in OpenCL


### PR DESCRIPTION
## Summary

Adds an opt-in batched `mul_mat` path for the RKNPU2 backend that collapses per-head matmul submissions into a single NPU dispatch per segment when the input layout allows it. Behind `RKNPU_BATCHED_MM_ENABLE=1`; default off, so current behavior is preserved bit-for-bit when the flag is unset.

The patch was developed and validated on a fork that was synced with upstream `ggml-org/llama.cpp`. This PR cherry-picks only the 14 commits that touch `ggml/src/ggml-rknpu2/ggml-rknpu2.cpp` and `tests/test-backend-ops.cpp`, so the diff stays scoped to the RKNPU2 backend.

## What it does

- **F8.2 (dynamic-B path):** opens an alternative dispatch route in `graph_compute` that targets `dynamic_matmul_run` for batched / B-dynamic matmuls.
- **F8.3 (`n_head_q` loop, gated):** lifts the original `n_head_q` head loop behind the env flag so a 3D `src1` can be flattened in place.
- **F8.5 (instrumentation):** atomic per-process route counters emitted on `backend_free` as `RKNPU_ROUTE_STATS`. Buckets every `mul_mat` that reaches the backend into accepted / rejected by reason and by static / dynamic dispatch + `set_tensor` pipelining stats. Useful to reason about why a given workload does or does not see speedups without a profiler attached.
- **F8.5.CLEAN (rc=139 fix):** corrects backend teardown order in `ggml_backend_rknpu_free` so `c_buffer_cache` entries are cleared *before* their parent `dynamic_matmul_ctx_cache` ctxes. The previous order produced an `rc=139` segfault on shutdown because the buffer destructor dereferenced already-destroyed dynamic-matmul handles.
- **F8.6a / F8.6b (gating):**
  - Reject batched dispatch when `M < 16` (small-M decode is faster on the static rank-2 path).
  - Flatten heads into a single `M_total = M * n_heads` submission per segment.
  - Optional CBUF cap (`RKNPU_BATCHED_MM_ENABLE_CBUF_CAP`, opt-in within opt-in, default off): hard-rejects when `M_total` exceeds a `12-2` coefficient × CBUF / `K * type_a_bytes` threshold. The formula derives from a separate pure-C NPU runtime and turned out to be over-conservative for `librknnrt 2.3.2`, so it stays gated until validated more broadly.
- **TST.1 / TST.2 / TST.3 (test coverage + helpers):**
  - `tests/test-backend-ops.cpp`: synthetic `MUL_MAT` cases that exercise the rank-2 / rank-3 paths and the small-M / large-M boundaries the gates rely on.
  - Backend-side: keep raw GGUF bytes in `tensor->data` on `set_tensor`, plus a `RKNPU_FORCE_DYNAMIC` env to force the dynamic route in tests so `buffer_clear` can see `tensor->data`.
- **Codex re-review fixes (final commit):** `domain_id` reuse + partial `set_tensor` correctness fixes from a downstream review pass.

## Validation (RK3588, kernel 6.1.115-vendor-rk35xx, librknnrt 2.3.2)

Model: `gemma-4-E2B-it-Q8_0`. CPU pinned to A76 cluster (cpus 4-7), `RKNPU_CORES=0,1,2`, performance governor on all clusters and on the NPU devfreq.

| Metric        | OFF (default)        | ON (`BATCHED_MM_ENABLE=1`) | Δ                              |
|---------------|----------------------|----------------------------|---------------------------------|
| PPL c=512     | 158.8719 ± 5.28901   | bit-identical              | n/a                             |
| pp512 (t/s)   | 95.99 ± 0.28         | 99.89 ± 0.35               | **+4.06%** (σ non-overlapping) |
| tg128 (t/s)   | 8.31 ± 0.02          | 8.24 ± 0.03                | -0.84% (within noise)          |

Telemetry from `RKNPU_ROUTE_STATS`:

- OFF pp512: `rejected_batched_off=420, accepted_batched=0`. Gating respected.
- ON pp512: `rejected_batched_off=0, accepted_batched=280, rejected_min_m=140`. Threshold filters small matmuls correctly; `accepted_rank2=1482` (the rank-2 single-head route) is unchanged from OFF.
- ON tg128: `accepted_batched=490` but `dispatched_static=80135` dominates because decode is batch=1 — batched-mm does not apply on autoregressive single-token steps.
- No RKNN errors, no `rc=139` shutdown crashes, no leaks across back-to-back runs.

Decode (`tg128`) does not benefit, which is expected given the autoregressive batch=1 dispatch. The win is on prefill (`pp512`).

## Why opt-in (default off)

- The +4 % on `pp512` is real but modest. The two opt-in caps (`RKNPU_BATCHED_MM_ENABLE` itself and the CBUF cap inside it) preserve current behavior bit-for-bit when unset.
- Coverage so far is `gemma-4 E2B Q8_0` only. Llama 3.2 and Qwen3 are still pending. Flipping default-on is not justified yet.
- The CBUF cap formula still needs reconciliation against `librknnrt 2.3.2` before it stops being opt-in within opt-in.

## Caveats / next steps

- `rejected_min_m` (140 pp / 350 tg) and `rejected_other` (497 pp / 923 tg) still exclude ~40 % of the batched candidates. Revisiting the min-M threshold and breaking `rejected_other` down by concrete cause (broadcast, row-contiguity, shape constraints) is the natural follow-up.

## Test plan

- [x] `llama-perplexity` on `wikitext-2-raw`, c=512 — bit-identical to pre-merge baseline (`158.8719 ± 5.28901`).
- [x] `llama-bench` on `gemma-4-E2B-Q8_0` with flag OFF and ON — flag OFF matches pre-merge, ON gains `pp512`.
- [x] Local sanity build against `invisi/rknpu2` as the merge base — clean compile (only pre-existing jinja warnings unrelated to this patch).
- [ ] Coverage on Llama 3.2 / Qwen3 — pending; will be tracked in a follow-up before any default-on flip is proposed.