### PR TITLE
devops : add containerized RKNPU2 build + run guide

### DIFF
--- a/.devops/rknpu2.Dockerfile
+++ b/.devops/rknpu2.Dockerfile
@@ -1,0 +1,42 @@
+# Containerized RKNPU2 build of llama.cpp — Rockchip NPU GGML backend.
+#
+# Builds the in-tree source with the RKNPU2 backend and ships llama-server together with the
+# vendored Rockchip runtime (librknnrt.so). Target: arm64 / RK3588(S) (e.g. Orange Pi 5 / 5 Pro).
+#
+# The NPU is reached from the container via the host DRM render node + dma-heap, so run with the
+# devices mapped in, e.g.:
+#   docker run --rm -p 8080:8080 \
+#     --device /dev/dri --device /dev/dma_heap \
+#     -e RKNPU_HYBRID=W8A8_STANDARD --ulimit nofile=65536 \
+#     -v /path/to/models:/models \
+#     <image> -m /models/model-Q8_0.gguf --host 0.0.0.0 --port 8080 -np 1 --jinja
+# See docs/rknpu2-docker.md for the full run guide (quantization, tool-calling, caveats).
+
+ARG UBUNTU_VERSION=bookworm
+
+FROM debian:${UBUNTU_VERSION} AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential cmake git ca-certificates libcurl4-openssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+COPY . .
+RUN cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DLLAMA_RKNPU2=ON \
+        -DLLAMA_CURL=ON \
+    && cmake --build build -j"$(nproc)" --target llama-server llama-cli llama-bench
+
+FROM debian:${UBUNTU_VERSION}-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libcurl4 libgomp1 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+# Built binaries + the ggml/llama shared libraries (incl. libggml-rknpu2.so).
+COPY --from=build /src/build/bin/ /opt/llama/bin/
+# Vendored Rockchip NPU userspace runtime — libggml-rknpu2.so dlopens/links against it at runtime.
+COPY --from=build /src/ggml/src/ggml-rknpu2/libs/librknnrt.so /usr/lib/librknnrt.so
+RUN ldconfig
+ENV LD_LIBRARY_PATH=/opt/llama/bin
+WORKDIR /opt/llama
+EXPOSE 8080
+ENTRYPOINT ["/opt/llama/bin/llama-server"]
+CMD ["--help"]

--- a/docs/rknpu2-docker.md
+++ b/docs/rknpu2-docker.md
@@ -1,0 +1,82 @@
+# Running the RKNPU2 backend in a container
+
+This guide covers building and running the Rockchip NPU (RKNPU2) backend of llama.cpp as a container on
+RK3588(S) boards (Orange Pi 5 / 5 Pro, Radxa Rock 5, etc.). The Dockerfile is
+[`.devops/rknpu2.Dockerfile`](../.devops/rknpu2.Dockerfile).
+
+## Requirements (host)
+
+- An RK3588(S) board on a **Rockchip BSP / vendor kernel** (e.g. Armbian `*-vendor-rk35xx`, kernel 6.1).
+  The mainline kernel does **not** expose the `rknpu` driver that the userspace runtime binds to.
+- RKNPU kernel driver **≥ 0.9.6** (check: `cat /sys/kernel/debug/rknpu/version`). Avoid 0.9.7.
+- The NPU exposed as a DRM render node plus the dma-heap devices. On most boards the NPU is
+  `/dev/dri/renderD129` and the GPU is `renderD128`, **but the numbering is not stable across boots /
+  kernels** — map the whole `/dev/dri` directory rather than a fixed node.
+
+The container bundles the matching `librknnrt.so` (vendored in the repo), so the host does not need it.
+
+## Build
+
+```sh
+docker build -f .devops/rknpu2.Dockerfile -t rk-llama-server .
+```
+
+The image is arm64-native; build it on the board (or any arm64 builder) — no cross-compile/QEMU needed.
+
+## Run
+
+```sh
+docker run --rm -p 8080:8080 \
+  --device /dev/dri --device /dev/dma_heap \
+  -e RKNPU_HYBRID=W8A8_STANDARD \
+  --ulimit nofile=65536 \
+  -v "$PWD/models:/models" \
+  rk-llama-server \
+  -m /models/your-model-Q8_0.gguf --host 0.0.0.0 --port 8080 -np 1 --jinja
+```
+
+Then hit the OpenAI-compatible API at `http://localhost:8080/v1`.
+
+If your runtime/distro restricts device access, `--privileged` (instead of the `--device` flags) is the
+simplest fallback for a trusted host.
+
+## Notes & recommendations
+
+- **Use `Q8_0` GGUF.** The backend requantizes GGUF weights into the NPU's native formats at load; the
+  `Q8_0 → W8A8` path is the fast one. `Q4_0` (→ W4A4-Hadamard) is noticeably slower on the NPU.
+- **The NPU's win is prompt processing (prefill / time-to-first-token)** — typically several times faster
+  than CPU. Token generation is roughly on par with CPU. Long prompts benefit most.
+- **One NPU consumer per device.** Running two processes that touch the NPU simultaneously can crash the
+  inference process (and, on some driver versions, the system). Keep a single `llama-server` per board and
+  serialize (`-np 1`).
+- **`--jinja`** uses the model's embedded chat template, which is required for correct tool/function
+  calling. Models with a dedicated tool-call format in llama.cpp (e.g. Gemma) return structured
+  `tool_calls`.
+- For best/steadiest throughput, pin the NPU devfreq governor to `performance`:
+  `echo performance | sudo tee /sys/class/devfreq/*npu*/governor`.
+- `RKNPU_DEVICE` selects the SoC (default `RK3588`); `RKNPU_CORES` restricts cores (default = all 3).
+
+## Kubernetes
+
+Map the whole `/dev/dri` directory and `/dev/dma_heap` via `hostPath`, run privileged, and pin one pod
+per node:
+
+```yaml
+spec:
+  nodeName: <board-node>
+  containers:
+    - name: rk-llama-server
+      image: rk-llama-server
+      args: ["-m", "/models/model-Q8_0.gguf", "--host", "0.0.0.0", "--port", "8080", "-np", "1", "--jinja"]
+      env:
+        - { name: RKNPU_HYBRID, value: W8A8_STANDARD }
+      securityContext: { privileged: true }
+      volumeMounts:
+        - { name: dri,      mountPath: /dev/dri }
+        - { name: dma-heap, mountPath: /dev/dma_heap }
+        - { name: models,   mountPath: /models }
+  volumes:
+    - { name: dri,      hostPath: { path: /dev/dri,      type: Directory } }
+    - { name: dma-heap, hostPath: { path: /dev/dma_heap, type: Directory } }
+    - { name: models,   persistentVolumeClaim: { claimName: models } }
+```


### PR DESCRIPTION
Adds a containerized build + run guide for the RKNPU2 backend:
- `.devops/rknpu2.Dockerfile` — multi-stage arm64 build
- `docs/rknpu2-docker.md` — run guide (device passthrough, quantization, tool-calling, single-consumer caveat)

Hey folks. I've been working on getting rk-llama.cpp (server) running inside a container on kubernetes. This is a multi step Dockerfile to both build and create a "production" runtime container as a final artifact. I run this in my raspberry pi / orange pi k3s cluster and build the container and run these on Orange Pi 5 Pros with gemma4:4B models. I load balance them with litellm proxy and use it for small stuff like evaluating emails and slack messages. Works great and wanted to share. I've personally reviewed and tweaked everything but AI did the iteration. 